### PR TITLE
Format compilation errors with the appropriate colon convention.

### DIFF
--- a/compiler/iface/MkIface.hs
+++ b/compiler/iface/MkIface.hs
@@ -61,7 +61,6 @@ Basic idea:
 #include "HsVersions.h"
 
 import GhcPrelude
-import qualified GHC.LanguageExtensions as LangExt
 
 import IfaceSyn
 import BinFingerprint

--- a/compiler/main/DynFlags.hs
+++ b/compiler/main/DynFlags.hs
@@ -652,9 +652,6 @@ data GeneralFlag
 
    | Opt_G_NoStateHack
    | Opt_G_NoOptCoercion
-
-   -- use "new colon convention" in error messages
-   | Opt_PrintNewColonConvention
    deriving (Eq, Show, Enum)
 
 -- Check whether a flag should be considered an "optimisation flag"
@@ -1654,7 +1651,7 @@ positionIndependent dflags = gopt Opt_PIC dflags || gopt Opt_PIE dflags
 
 -- | Display error messages using the "new colon convention"?
 performNewColonConvention :: DynFlags -> Bool
-performNewColonConvention = gopt Opt_PrintNewColonConvention
+performNewColonConvention = xopt LangExt.NewColonConvention
 
 -----------------------------------------------------------------------------
 -- Ways
@@ -4183,7 +4180,6 @@ fFlagsDeps = [
   flagSpec "print-expanded-synonyms"          Opt_PrintExpandedSynonyms,
   flagSpec "print-potential-instances"        Opt_PrintPotentialInstances,
   flagSpec "print-typechecker-elaboration"    Opt_PrintTypecheckerElaboration,
-  flagSpec "print-new-colon-convention"       Opt_PrintNewColonConvention,
   flagSpec "prof-cafs"                        Opt_AutoSccsOnIndividualCafs,
   flagSpec "prof-count-entries"               Opt_ProfCountEntries,
   flagSpec "regs-graph"                       Opt_RegsGraph,
@@ -4347,7 +4343,6 @@ xFlagsDeps = [
   flagSpec "BangPatterns"                     LangExt.BangPatterns,
   flagSpec "BinaryLiterals"                   LangExt.BinaryLiterals,
   flagSpec "CApiFFI"                          LangExt.CApiFFI,
-  flagSpec "NewColonConvention"               LangExt.NewColonConvention,
   flagSpec "CPP"                              LangExt.Cpp,
   flagSpec "ConstrainedClassMethods"          LangExt.ConstrainedClassMethods,
   flagSpec "ConstraintKinds"                  LangExt.ConstraintKinds,
@@ -4420,6 +4415,7 @@ xFlagsDeps = [
   flagSpec "NamedWildCards"                   LangExt.NamedWildCards,
   flagSpec "NegativeLiterals"                 LangExt.NegativeLiterals,
   flagSpec "HexFloatLiterals"                 LangExt.HexFloatLiterals,
+  flagSpec "NewColonConvention"               LangExt.NewColonConvention,
   flagSpec "NondecreasingIndentation"         LangExt.NondecreasingIndentation,
   depFlagSpec' "NullaryTypeClasses"           LangExt.NullaryTypeClasses
     (deprecatedForExtension "MultiParamTypeClasses"),

--- a/compiler/main/GHC.hs
+++ b/compiler/main/GHC.hs
@@ -636,7 +636,7 @@ setProgramDynFlags_ invalidate_needed dflags = do
 -- that the next downsweep will think that all the files have changed
 -- and preprocess them again.  This won't necessarily cause everything
 -- to be recompiled, because by the time we check whether we need to
--- recopmile a module, we'll have re-summarised the module and have a
+-- recompile a module, we'll have re-summarised the module and have a
 -- correct ModSummary.
 --
 invalidateModSummaryCache :: GhcMonad m => m ()

--- a/compiler/typecheck/FamInst.hs
+++ b/compiler/typecheck/FamInst.hs
@@ -168,9 +168,9 @@ newFamInst flavor axiom@(CoAxiom { co_ax_tc = fam_tc })
        ; let lhs'     = substTys subst lhs
              rhs'     = substTy  subst rhs
              tcvs'    = tvs' ++ cvs'
-       ; ifErrsM (return ()) $ -- Don't lint when there are errors, because
-                               -- errors might mean TcTyCons.
-                               -- See Note [Recover from validity error] in TcTyClsDecls
+       ; whenNoErrs $ -- Don't lint when there are errors, because
+                      -- errors might mean TcTyCons.
+                      -- See Note [Recover from validity error] in TcTyClsDecls
          when (gopt Opt_DoCoreLinting dflags) $
            -- Check that the types involved in this instance are well formed.
            -- Do /not/ expand type synonyms, for the reasons discussed in

--- a/compiler/typecheck/TcRnDriver.hs
+++ b/compiler/typecheck/TcRnDriver.hs
@@ -2768,7 +2768,7 @@ ppr_types debug type_env
              -- etc are suppressed (unless -dppr-debug),
              -- because they appear elsehwere
 
-    ppr_sig id = hang (ppr id <+> dcolon) 2 (ppr (tidyTopType (idType id)))
+    ppr_sig id = hang (ppr id <+> of_type) 2 (ppr (tidyTopType (idType id)))
 
 ppr_tycons :: Bool -> [FamInst] -> TypeEnv -> SDoc
 ppr_tycons debug fam_insts type_env
@@ -2787,7 +2787,7 @@ ppr_tycons debug fam_insts type_env
                                     not (tycon `elem` fi_tycons)
     ppr_tc tc
        = vcat [ hang (ppr (tyConFlavour tc) <+> ppr tc
-                      <> braces (ppr (tyConArity tc)) <+> dcolon)
+                      <> braces (ppr (tyConArity tc)) <+> of_type)
                    2 (ppr (tidyTopType (tyConKind tc)))
               , nest 2 $
                 ppWhen show_roles $
@@ -2809,7 +2809,7 @@ ppr_datacons debug type_env
   = ppr_things "DATA CONSTRUCTORS" ppr_dc wanted_dcs
       -- The filter gets rid of class data constructors
   where
-    ppr_dc dc = ppr dc <+> dcolon <+> ppr (dataConUserType dc)
+    ppr_dc dc = ppr dc <+> of_type <+> ppr (dataConUserType dc)
     all_dcs    = typeEnvDataCons type_env
     wanted_dcs | debug     = all_dcs
                | otherwise = filterOut is_cls_dc all_dcs
@@ -2820,7 +2820,7 @@ ppr_patsyns type_env
   = ppr_things "PATTERN SYNONYMS" ppr_ps
                (typeEnvPatSyns type_env)
   where
-    ppr_ps ps = ppr ps <+> dcolon <+> pprPatSynType ps
+    ppr_ps ps = ppr ps <+> of_type <+> pprPatSynType ps
 
 ppr_insts :: [ClsInst] -> SDoc
 ppr_insts ispecs


### PR DESCRIPTION
This improves support for the NewColonConvention language extension.
Previously, errors messages from ghc would contain code fragments
displayed using the traditional colon convention, regardless of whether
the language extension was set. This change means that the new colon
convention will be used to display errors IF the language extension is
set globally in the dynamic flags.

If you are testing the new colon convention with ghc from the command line,
you should use the `-XNewColonConvention` flag. Using the language
extension pragma in the source files will allow you to use the swapped
colon convention in those files, but the error will still be
displayed with the standard convention. This is because the dynamic
flags set at the time the error is rendered in the main function in Main.hs
do not include the flags set by pragmas in the individual files. Instead of
working around this, for now we say that if you want errors displayed in
the new style, you have to use the command line flag.

In an application using ghc as a library, you should set the
NewColonConvention language extension as one of the global DynFlags. The
application can catch the SourceError that is thrown as an exception.
You still need to take care to display that error using the correct
dynamic flags.