### PR TITLE
Flexible choices (1)

### DIFF
--- a/compiler/parser/Lexer.x
+++ b/compiler/parser/Lexer.x
@@ -653,6 +653,7 @@ data Token
   | ITsignatory
   | ITagreement
   | ITcontroller
+  | ITchoice
   | ITobserver
   | ITnonconsuming
 
@@ -875,20 +876,21 @@ reservedWordsFM = listToUFM $
          ( "prim",           ITprimcallconv,  xbit FfiBit),
          ( "javascript",     ITjavascriptcallconv, xbit FfiBit),
 
+         ( "daml",           ITdaml,          xbit DamlVersionRequiredBit),
+         ( "template",       ITtemplate,      xbit DamlTemplateBit),
+         ( "can",            ITcan,           xbit DamlTemplateBit),
+         ( "ensure",         ITensure,        xbit DamlTemplateBit),
+         ( "signatory",      ITsignatory,     xbit DamlTemplateBit),
+         ( "agreement",      ITagreement,     xbit DamlTemplateBit),
+         ( "controller",     ITcontroller,    xbit DamlTemplateBit),
+         ( "choice",         ITchoice,        xbit DamlTemplateBit),
+         ( "observer",       ITobserver,      xbit DamlTemplateBit),
+         ( "nonconsuming",   ITnonconsuming,  xbit DamlTemplateBit),
+
          ( "unit",           ITunit,          0 ),
          ( "dependency",     ITdependency,       0 ),
          ( "signature",      ITsignature,     0 ),
 
-         ( "daml",           ITdaml,          xbit DamlVersionRequiredBit),
-         ( "template",       ITtemplate,      xbit DamlTemplateBit),
-         ( "can",            ITcan,           xbit DamlTemplateBit),
-           -- See Note [Lexing type pseudo-keywords]
-         ( "ensure",         ITensure,        0 ),
-         ( "signatory",      ITsignatory,     0 ),
-         ( "agreement",      ITagreement,     0 ),
-         ( "controller",     ITcontroller,    0 ),
-         ( "observer",       ITobserver,      0 ),
-         ( "nonconsuming",   ITnonconsuming,  0 ),
          ( "rec",            ITrec,           xbit ArrowsBit .|.
                                               xbit RecursiveDoBit),
          ( "proc",           ITproc,          xbit ArrowsBit)
@@ -908,9 +910,9 @@ on. In fact, by unconditionally lexing these pseudo-keywords as special, we
 can get better error messages.
 
 We use the same technique for the DamlTemplate keywords 'ensure',
-'signatory', 'agreement', 'controller', 'observer' and nonconsuming
-which all serve as markers for special kinds of declarations inside a
-template declaration context.
+'signatory', 'agreement', 'controller', 'choice' 'observer' and
+'nonconsuming' which all serve as markers for special kinds of
+declarations inside a template declaration context.
 
 Also, note that these are included in the `varid` production in the parser --
 a key detail to make all this work.

--- a/compiler/parser/Lexer.x
+++ b/compiler/parser/Lexer.x
@@ -1546,6 +1546,7 @@ maybe_layout t = do -- If the alternative layout rule is enabled then
           f ITlet   = pushLexState layout
           f ITwhere = pushLexState layout
           f ITwith  = pushLexState layout
+          f ITcontroller = pushLexState layout
           f ITcan   = pushLexState layout
           f ITrec   = pushLexState layout
           f ITif    = pushLexState layout_if

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -3287,7 +3287,7 @@ transformqual :: { Located ([AddAnn],[LStmt GhcPs (LHsExpr GhcPs)] -> Stmt GhcPs
             {% runExpCmdP $4 >>= \ $4 ->
                runExpCmdP $6 >>= \ $6 ->
                return $ sLL $1 $> ([mj AnnThen $1,mj AnnGroup $2,mj AnnBy $3,mj AnnUsing $5],
-     \ss -> (mkGroupByUsingStmt ss $4 $6)) }
+                                   \ss -> (mkGroupByUsingStmt ss $4 $6)) }
 
 -- Note that 'group' is a special_id, which means that you can enable
 -- TransformListComp while still using Data.List.group. However, this

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1209,9 +1209,17 @@ choice_decl :: { Located ChoiceDecl }
                        , cdChoiceDoc          = $5 }
     }
 
-flexible_choice_decl :: { Located () }
+flexible_choice_decl :: { Located FlexChoiceDecl }
   : nonconsuming 'choice' qtycon OF_TYPE btype_ maybe_docprev arecord_with_opt 'controller' parties 'can' flexible_choice_body
-    { sL0 () }
+    { sL (comb3 $1 $2 $>) $
+        FlexChoiceDecl { fcdChoiceName = $3
+                       , fcdChoiceReturnTy = $5
+                       , fcdChoiceFields = $7
+                       , fcdControllers = applyConcat $9
+                       , fcdChoiceBody = $11
+                       , fcdChoiceNonConsuming = $1
+                       , fcdChoiceDoc = $6 }
+    }
 
 flexible_choice_body :: { Located ([AddAnn],[LStmt GhcPs (LHsExpr GhcPs)]) }
   : '{' 'do' stmtlist '}'

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2626,7 +2626,7 @@ mkTemplateControllerFunBindDecl
   -> P (Maybe (LHsBind GhcPs))   -- function binding
 mkTemplateControllerFunBindDecl _ Nothing _ = return Nothing
 mkTemplateControllerFunBindDecl conName (Just body) binds = do
-  let tag = noLoc $ mkRdrUnqual (mkVarOcc "choice_controller")
+  let tag = noLoc $ mkRdrUnqual (mkVarOcc "choiceController")
       this = AsPat noExt
         (noLoc $ mkRdrUnqual (mkVarOcc "this"))
         (noLoc $ ConPatIn conName $

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2626,7 +2626,7 @@ mkTemplateControllerFunBindDecl
   -> P (Maybe (LHsBind GhcPs))   -- function binding
 mkTemplateControllerFunBindDecl _ Nothing _ = return Nothing
 mkTemplateControllerFunBindDecl conName (Just body) binds = do
-  let tag = noLoc $ mkRdrUnqual (mkVarOcc "controller")
+  let tag = noLoc $ mkRdrUnqual (mkVarOcc "choice_controller")
       this = AsPat noExt
         (noLoc $ mkRdrUnqual (mkVarOcc "this"))
         (noLoc $ ConPatIn conName $

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -44,6 +44,7 @@ module   RdrHsSyn (
 
         -- DAML Template Syntax
         ChoiceDecl(..),
+        FlexChoiceDecl(..),
         TemplateBodyDecl(..),
         mkTemplateDecl,
         applyToParties,
@@ -2504,12 +2505,22 @@ mkInlinePragma src (inl, match_info) mb_act
 -- DAML Template Syntax
 
 data ChoiceDecl = ChoiceDecl
-  { cdChoiceName         :: Located RdrName
-  , cdChoiceFields       :: Maybe (LHsType GhcPs)
-  , cdChoiceReturnTy     :: LHsType GhcPs
-  , cdChoiceBody         :: Located ([AddAnn],[LStmt GhcPs (LHsExpr GhcPs)])
-  , cdChoiceNonConsuming :: Located Bool
-  , cdChoiceDoc          :: Maybe LHsDocString
+  { cdChoiceName          :: Located RdrName
+  , cdChoiceFields        :: Maybe (LHsType GhcPs)
+  , cdChoiceReturnTy      :: LHsType GhcPs
+  , cdChoiceBody          :: Located ([AddAnn],[LStmt GhcPs (LHsExpr GhcPs)])
+  , cdChoiceNonConsuming  :: Located Bool
+  , cdChoiceDoc           :: Maybe LHsDocString
+  }
+
+data FlexChoiceDecl = FlexChoiceDecl
+  { fcdChoiceName         :: Located RdrName
+  , fcdChoiceReturnTy     :: LHsType GhcPs
+  , fcdChoiceFields       :: Maybe (LHsType GhcPs)
+  , fcdControllers        :: LHsExpr GhcPs
+  , fcdChoiceBody         :: Located ([AddAnn],[LStmt GhcPs (LHsExpr GhcPs)])
+  , fcdChoiceNonConsuming :: Located Bool
+  , fcdChoiceDoc          :: Maybe LHsDocString
   }
 
 data TemplateBodyDecl
@@ -2519,7 +2530,7 @@ data TemplateBodyDecl
   | AgreementDecl (LHsExpr GhcPs)
   | ChoiceGroupDecl (Located (LHsExpr GhcPs, Located [Located ChoiceDecl]))
   | LetBindingsDecl (Located ([AddAnn], LHsLocalBinds GhcPs))
-  | FlexibleChoiceDecl (Located ())
+  | FlexibleChoiceDecl (Located FlexChoiceDecl)
 
 -- | Classify a list of template body declarations.
 extractTemplateBodyDecls ::
@@ -2530,7 +2541,7 @@ extractTemplateBodyDecls ::
      , [LHsExpr GhcPs] -- agreement
      , [Located (LHsExpr GhcPs, Located [Located ChoiceDecl])] -- controlled choice groups
      , [LHsLocalBinds GhcPs] -- let bindings
-     , [Located ()] -- flexible choices
+     , [Located FlexChoiceDecl] -- flexible choices
      )
 extractTemplateBodyDecls = foldl extract ([], [], [], [], [], [], [])
   where

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2519,6 +2519,7 @@ data TemplateBodyDecl
   | AgreementDecl (LHsExpr GhcPs)
   | ChoiceGroupDecl (Located (LHsExpr GhcPs, Located [Located ChoiceDecl]))
   | LetBindingsDecl (Located ([AddAnn], LHsLocalBinds GhcPs))
+  | FlexibleChoiceDecl (Located ())
 
 -- | Classify a list of template body declarations.
 extractTemplateBodyDecls ::
@@ -2528,18 +2529,20 @@ extractTemplateBodyDecls ::
      , [LHsExpr GhcPs] -- observers (list of lists)
      , [LHsExpr GhcPs] -- agreement
      , [Located (LHsExpr GhcPs, Located [Located ChoiceDecl])] -- controlled choice groups
-     , [LHsLocalBinds GhcPs]
+     , [LHsLocalBinds GhcPs] -- let bindings
+     , [Located ()] -- flexible choices
      )
-extractTemplateBodyDecls = foldl extract ([], [], [], [], [], [])
+extractTemplateBodyDecls = foldl extract ([], [], [], [], [], [], [])
   where
-    extract (es, ss, os, as, gs, bs) (L _ decl) =
+    extract (es, ss, os, as, gs, bs, fs) (L _ decl) =
       case decl of
-        EnsureDecl e                 -> (e : es, ss, os, as, gs, bs)
-        SignatoryDecl s              -> (es, s : ss, os, as, gs, bs)
-        ObserverDecl o               -> (es, ss, o : os, as, gs, bs)
-        AgreementDecl a              -> (es, ss, os, a : as, gs, bs)
-        ChoiceGroupDecl g            -> (es, ss, os, as, g : gs, bs)
-        LetBindingsDecl (L _ (_, b)) -> (es, ss, os, as, gs, b : bs)
+        EnsureDecl e                 -> (e : es, ss, os, as, gs, bs, fs)
+        SignatoryDecl s              -> (es, s : ss, os, as, gs, bs, fs)
+        ObserverDecl o               -> (es, ss, o : os, as, gs, bs, fs)
+        AgreementDecl a              -> (es, ss, os, a : as, gs, bs, fs)
+        ChoiceGroupDecl g            -> (es, ss, os, as, g : gs, bs, fs)
+        LetBindingsDecl (L _ (_, b)) -> (es, ss, os, as, gs, b : bs, fs)
+        FlexibleChoiceDecl f         -> (es, ss, os, as, gs, bs, f : fs)
 
 -- | Calculates the application of a 'toParties' function to an
 -- expression (invoked from Parser.y).
@@ -2985,11 +2988,11 @@ checkTemplateDeclConstraints nloc ens agr bns
 mkTemplateDecl
   :: Located RdrName -- The template name
   -> LHsType GhcPs -- The template's record type
-  -> Located [Located TemplateBodyDecl]  -- Functions and choice groups
+  -> Located [Located TemplateBodyDecl]  -- Functions, controlled choice groups, flexible choices
   -> P (OrdList (LHsDecl GhcPs)) -- Desugared declarations
 mkTemplateDecl lname@(L nloc _name) fields (L _ decls) = do
   let dataName = L nloc (HsTyVar noExt NotPromoted lname)
-      (ens, sig, obs, agr, cgs, binds) = extractTemplateBodyDecls decls
+      (ens, sig, obs, agr, cgs, binds, _flxs) = extractTemplateBodyDecls decls
       sig' =
         if null sig
           then Nothing


### PR DESCRIPTION
In this PR, we introduce syntax for flexible choices. Example:
```
choice Transfer : ContractId Iou with
    newOwner : Party
  controller owner
  do
    create this with owner = newOwner
```
