### PR TITLE
Refactoring of data structure names for choices

### DIFF
--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1175,33 +1175,33 @@ template_body_decl :: { Located TemplateBodyDecl }
   | agreement_decl                               { sL1 $1 $ AgreementDecl $1 }
   | choice_group_decl                            { sL1 $1 $ ChoiceGroupDecl $1 }
   | let_bindings_decl                            { sL1 $1 $ LetBindingsDecl $1 }
-  | flex_choice_decl                             { sL1 $1 $ FlexibleChoiceDecl $1 }
+  | flex_choice_decl                             { sL1 $1 $ FlexChoiceDecl $1 }
 
 let_bindings_decl :: { Located ([AddAnn], Located (HsLocalBinds GhcPs)) }
   : 'let' binds                 { sLL $1 $> (mj AnnWhere $1 : (fst $ unLoc $2)
                                              , snd $ unLoc $2) }
 
-choice_group_decl :: { Located (LHsExpr GhcPs , Located [Located ChoiceDecl]) }
+choice_group_decl :: { Located (LHsExpr GhcPs , Located [Located ChoiceData]) }
   : 'controller' party_list 'can' choice_decl_list  { sLL $1 $> (applyConcat $2, $4) }
 
-choice_decl_list :: { Located [Located ChoiceDecl] }
+choice_decl_list :: { Located [Located ChoiceData] }
   : '{' choice_decls '}'                         { sLL $1 $3 $ reverse (unLoc $2) }
   | vocurly choice_decls close                   { let cs = reverse (unLoc $2) in
                                                     L (comb2 $1
                                                         (last (void $1:map void cs))
                                                       ) $ cs }
 
-choice_decls :: { Located [Located ChoiceDecl] }
+choice_decls :: { Located [Located ChoiceData] }
  : choice_decls ';' choice_decl                  { sLL $1 $> $ $3 : (unLoc $1) }
  | choice_decls ';'                              { sLL $1 $> $ unLoc $1 }
  | choice_decl                                   { sL1 $1 [$1] }
  | {- empty -}                                   { sL0 [] }
 
-choice_decl :: { Located ChoiceDecl }
+choice_decl :: { Located ChoiceData }
   : nonconsuming qtycon OF_TYPE btype_ maybe_docprev arecord_with_opt 'do' stmtlist -- note the use of 'btype_'
     {% $8 >>= \ $8 ->
         return $ sL (comb3 $1 $2 $>) $
-            ChoiceDecl { cdChoiceName         = $2
+            ChoiceData { cdChoiceName         = $2
                        , cdChoiceReturnTy     = $4
                        , cdChoiceFields       = $6
                        , cdChoiceBody         = $8
@@ -1209,11 +1209,11 @@ choice_decl :: { Located ChoiceDecl }
                        , cdChoiceDoc          = $5 }
     }
 
-flex_choice_decl :: { Located FlexChoiceDecl }
+flex_choice_decl :: { Located FlexChoiceData }
   : nonconsuming 'choice' qtycon OF_TYPE btype_ maybe_docprev arecord_with_opt 'controller' party_list flexible_choice_body
     { sL (comb3 $1 $2 $>) $
-        FlexChoiceDecl (applyConcat $9)
-            ChoiceDecl { cdChoiceName = $3
+        FlexChoiceData (applyConcat $9)
+            ChoiceData { cdChoiceName = $3
                        , cdChoiceReturnTy = $5
                        , cdChoiceFields = $7
                        , cdChoiceBody = $10

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2989,7 +2989,7 @@ mkTemplateFlexChoiceDecls dataName conName flxs binds = do
   foldM f [] flxs
 } where {
     f :: [LHsDecl GhcPs] -> Located FlexChoiceData -> P ([LHsDecl GhcPs])
-  ; f acc (L loc (FlexChoiceDecl controllers choice_decl)) = do {
+  ; f acc (L loc (FlexChoiceData controllers choice_decl)) = do {
       decls <- mkTemplateChoiceDecls dataName conName
                                controllers (L loc choice_decl) ArgAsPat binds
     ; return (acc ++ decls)

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -43,8 +43,8 @@ module   RdrHsSyn (
         placeHolderPunRhs,
 
         -- DAML Template Syntax
-        ChoiceDecl(..),
-        FlexChoiceDecl(..),
+        ChoiceData(..),
+        FlexChoiceData(..),
         TemplateBodyDecl(..),
         mkTemplateDecl,
         applyToParties,
@@ -2505,7 +2505,7 @@ mkInlinePragma src (inl, match_info) mb_act
 ------------------------------------------------------------------------------
 -- DAML Template Syntax
 
-data ChoiceDecl = ChoiceDecl
+data ChoiceData = ChoiceData
   { cdChoiceName          :: Located RdrName
   , cdChoiceFields        :: Maybe (LHsType GhcPs)
   , cdChoiceReturnTy      :: LHsType GhcPs
@@ -2514,18 +2514,18 @@ data ChoiceDecl = ChoiceDecl
   , cdChoiceDoc           :: Maybe LHsDocString
   }
 
--- A `FlexChoiceDecl` is a `ChoiceDecl` augmented with its controller
+-- A `FlexChoiceData` is a `ChoiceData` augmented with its controller
 -- set.
-data FlexChoiceDecl = FlexChoiceDecl (LHsExpr GhcPs) ChoiceDecl
+data FlexChoiceData = FlexChoiceData (LHsExpr GhcPs) ChoiceData
 
 data TemplateBodyDecl
   = EnsureDecl (LHsExpr GhcPs)
   | SignatoryDecl (LHsExpr GhcPs)
   | ObserverDecl (LHsExpr GhcPs)
   | AgreementDecl (LHsExpr GhcPs)
-  | ChoiceGroupDecl (Located (LHsExpr GhcPs, Located [Located ChoiceDecl]))
+  | ChoiceGroupDecl (Located (LHsExpr GhcPs, Located [Located ChoiceData]))
   | LetBindingsDecl (Located ([AddAnn], LHsLocalBinds GhcPs))
-  | FlexibleChoiceDecl (Located FlexChoiceDecl)
+  | FlexChoiceDecl (Located FlexChoiceData)
 
 -- | Classify a list of template body declarations.
 extractTemplateBodyDecls ::
@@ -2534,9 +2534,9 @@ extractTemplateBodyDecls ::
      , [LHsExpr GhcPs] -- signatories (list of lists)
      , [LHsExpr GhcPs] -- observers (list of lists)
      , [LHsExpr GhcPs] -- agreement
-     , [Located (LHsExpr GhcPs, Located [Located ChoiceDecl])] -- controlled choice groups
+     , [Located (LHsExpr GhcPs, Located [Located ChoiceData])] -- controlled choice groups
      , [LHsLocalBinds GhcPs] -- let bindings
-     , [Located FlexChoiceDecl] -- flexible choices
+     , [Located FlexChoiceData] -- flexible choices
      )
 extractTemplateBodyDecls = foldl extract ([], [], [], [], [], [], [])
   where
@@ -2548,7 +2548,7 @@ extractTemplateBodyDecls = foldl extract ([], [], [], [], [], [], [])
         AgreementDecl a              -> (es, ss, os, a : as, gs, bs, fs)
         ChoiceGroupDecl g            -> (es, ss, os, as, g : gs, bs, fs)
         LetBindingsDecl (L _ (_, b)) -> (es, ss, os, as, gs, b : bs, fs)
-        FlexibleChoiceDecl f         -> (es, ss, os, as, gs, bs, f : fs)
+        FlexChoiceDecl f             -> (es, ss, os, as, gs, bs, f : fs)
 
 -- | Utility for calculating 'DA.Internal.Desugar' names referenced
 -- during desugaring.
@@ -2861,13 +2861,13 @@ mkTemplateChoiceInstDecl
   -> Located RdrName -- ctor 'T'
   -> Located RdrName -- ctor 'S'
   -> LHsExpr GhcPs   -- (list of) controllers
-  -> ChoiceDecl      -- choice 'S' (with result type 'R')
+  -> ChoiceData      -- choice 'S' (with result type 'R')
   -> ArgPattern      -- 'arg@S{..}' or '_'?
   -> Maybe (LHsLocalBinds GhcPs) -- local binds
   -> P (LHsDecl GhcPs)  -- resulting declaration
 mkTemplateChoiceInstDecl
   dataName choiceName conName
-    choiceConName controllers (ChoiceDecl{..}) argPatType binds = do
+    choiceConName controllers (ChoiceData{..}) argPatType binds = do
 { -- Function bindings.
   ; mbChoiceControllerDecl <-
       mkTemplateControllerFunBindDecl
@@ -2913,12 +2913,12 @@ mkTemplateChoiceDecls
   :: LHsType GhcPs -- data 'T'
   -> Located RdrName -- ctor 'T'
   -> LHsExpr GhcPs -- (list of) controllers
-  -> Located ChoiceDecl -- choice 'S' (with result type 'R')
+  -> Located ChoiceData -- choice 'S' (with result type 'R')
   -> ArgPattern -- 'arg@S{..}' or '_'?
   -> Maybe (LHsLocalBinds GhcPs) -- local binds
   -> P ([LHsDecl GhcPs]) -- resulting declarations
 mkTemplateChoiceDecls
-  dataName conName controllers (L _ (choice@ChoiceDecl{..})) argPatType binds = do
+  dataName conName controllers (L _ (choice@ChoiceData{..})) argPatType binds = do
 {
   -- Calculate data constructor info from the choice name and (maybe)
   -- record type.
@@ -2950,7 +2950,7 @@ mkTemplateChoiceDecls
 mkTemplateChoiceGroupDecls ::
        LHsType GhcPs                   -- data 'T'
     -> Located RdrName                 -- ctor 'T'
-    -> [Located (LHsExpr GhcPs, Located [Located ChoiceDecl])] -- choice groups
+    -> [Located (LHsExpr GhcPs, Located [Located ChoiceData])] -- choice groups
     -> Maybe (LHsLocalBinds GhcPs)     -- binds
     -> P ([LHsDecl GhcPs])             -- resulting declarations
 mkTemplateChoiceGroupDecls dataName conName cgs binds = do
@@ -2958,7 +2958,7 @@ mkTemplateChoiceGroupDecls dataName conName cgs binds = do
   foldM f [] cgs -- for each choice group
 } where {
     f :: [LHsDecl GhcPs]
-      -> Located (LHsExpr GhcPs, Located [Located ChoiceDecl])
+      -> Located (LHsExpr GhcPs, Located [Located ChoiceData])
       -> P ([LHsDecl GhcPs])
   ; f acc (L _ (controllers, (L _ choice_decls))) =  do { -- for each choice
         decls <- foldM (g controllers) [] choice_decls
@@ -2966,7 +2966,7 @@ mkTemplateChoiceGroupDecls dataName conName cgs binds = do
     } where {
         g :: LHsExpr GhcPs
           -> [LHsDecl GhcPs]
-          -> Located ChoiceDecl
+          -> Located ChoiceData
           -> P ([LHsDecl GhcPs])
       ; g controllers acc choice_decl = do {    -- harvest decls
           decls <- mkTemplateChoiceDecls dataName conName
@@ -2978,17 +2978,17 @@ mkTemplateChoiceGroupDecls dataName conName cgs binds = do
 
 -- | Contruct a @data S = S {...}@ and @instance Choice T S R@ for all
 -- choices with flexible controllers.
-mkTemplateFlexibleChoiceDecls ::
+mkTemplateFlexChoiceDecls ::
        LHsType GhcPs                   -- data 'T'
     -> Located RdrName                 -- ctor 'T'
-    -> [Located FlexChoiceDecl]        -- flexible choices
+    -> [Located FlexChoiceData]        -- flexible choices
     -> Maybe (LHsLocalBinds GhcPs)     -- binds
     -> P ([LHsDecl GhcPs])             -- resulting declarations
-mkTemplateFlexibleChoiceDecls dataName conName flxs binds = do
+mkTemplateFlexChoiceDecls dataName conName flxs binds = do
 {
   foldM f [] flxs
 } where {
-    f :: [LHsDecl GhcPs] -> Located FlexChoiceDecl -> P ([LHsDecl GhcPs])
+    f :: [LHsDecl GhcPs] -> Located FlexChoiceData -> P ([LHsDecl GhcPs])
   ; f acc (L loc (FlexChoiceDecl controllers choice_decl)) = do {
       decls <- mkTemplateChoiceDecls dataName conName
                                controllers (L loc choice_decl) ArgAsPat binds
@@ -3037,7 +3037,7 @@ mkTemplateDecl lname@(L nloc _name) fields (L _ decls) = do
   templateInstDecl <-
     mkTemplateTemplateInstDecl dataName conName ens' sig' obs'' agr' binds'
   choiceGroupDecls <- mkTemplateChoiceGroupDecls dataName conName cgs binds'
-  flexibleChoiceDecls <- mkTemplateFlexibleChoiceDecls dataName conName flxs binds'
+  flexibleChoiceDecls <- mkTemplateFlexChoiceDecls dataName conName flxs binds'
   return $ toOL ([dataDecl, templateInstDecl] ++ choiceGroupDecls ++ flexibleChoiceDecls)
   where
     -- | Calculate an expression for the full list of a contract's


### PR DESCRIPTION
In this PR, a small refactoring is made for choice data structures. `ChoiceDecl` is renamed `ChoiceData`, `FlexChoiceDecl` is renamed `FlexChoiceData` and the `FlexibleChoiceDecl` constructor is renamed `FlexChoiceDecl`. The motivation for adopting this naming scheme now is to introduce a little more regularity before introducing new types to support contract key syntax.