### PR TITLE
Contract key surface syntax

### DIFF
--- a/compiler/parser/Lexer.x
+++ b/compiler/parser/Lexer.x
@@ -656,6 +656,8 @@ data Token
   | ITchoice
   | ITobserver
   | ITnonconsuming
+  | ITkey
+  | ITmaintainer
 
   -- Pragmas, see  note [Pragma source text] in BasicTypes
   | ITinline_prag       SourceText InlineSpec RuleMatchInfo
@@ -886,6 +888,8 @@ reservedWordsFM = listToUFM $
          ( "choice",         ITchoice,        xbit DamlTemplateBit),
          ( "observer",       ITobserver,      xbit DamlTemplateBit),
          ( "nonconsuming",   ITnonconsuming,  xbit DamlTemplateBit),
+         ( "key",            ITkey,           xbit DamlTemplateBit),
+         ( "maintainer",     ITmaintainer,    xbit DamlTemplateBit),
 
          ( "unit",           ITunit,          0 ),
          ( "dependency",     ITdependency,       0 ),

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -3878,7 +3878,7 @@ varsym_no_minus :: { Located RdrName } -- varsym not including '-'
 -- These special_ids are treated as keywords in various places, but as
 -- ordinary ids elsewhere.  'special_id' collects all these except
 -- 'unsafe', 'interruptible', 'forall', 'family', 'role', 'stock', and
--- 'anyclass'whose treatment differs depending on context.
+-- 'anyclass' whose treatment differs depending on context.
 special_id :: { Located FastString }
 special_id
         : 'as'                  { sL1 $1 (fsLit "as") }

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1254,7 +1254,7 @@ agreement_decl :: { LHsExpr GhcPs }
 key_decl :: { Located KeyData }
     -- We use `infixexp` rather than `exp` here because we need to
     -- exclude the case `infixexp OF_TYPE sigtype`
-  : 'key' infixexp OF_TYPE sigtype               {% runExpCmdP $2 >>= \ $2 -> return $ sLL $1 $> $ KeyData { kdKeyExpr = $2, kdKeyTy = $4 } }
+  : 'key' infixexp OF_TYPE btype                 {% runExpCmdP $2 >>= \ $2 -> return $ sLL $1 $> $ KeyData { kdKeyExpr = $2, kdKeyTy = $4 } }
 
 maintainer_decl :: { LHsExpr GhcPs }
   : 'maintainer' parties                         { sLL $1 $> $ unLoc (applyConcat $2) }

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2819,7 +2819,7 @@ mkTemplateTypeDecl
         , tcdFixity   = Prefix
         , tcdDataDefn = dataDefn
         }
-  return $ [L loc $ TyClD noExt dataDecl]
+  return [L loc $ TyClD noExt dataDecl]
 
 -- | Construct an @instance Template T@.
 mkTemplateTemplateInstDecl ::

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2660,10 +2660,7 @@ funBind loc tag mg =
             }
 
 -- | Utility for constructing a class instance declaration.
-classInstDecl
-  :: (XCClsInstDecl pass ~ NoExt,
-       XHsIB pass (LHsType pass) ~ NoExt) =>
-     HsType pass -> LHsBinds pass -> ClsInstDecl pass
+classInstDecl :: HsType GhcPs -> LHsBinds GhcPs -> ClsInstDecl GhcPs
 classInstDecl tyApps funBinds =
   ClsInstDecl { cid_ext = noExt
               , cid_poly_ty = HsIB {

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2830,7 +2830,7 @@ mkTemplateTemplateInstDecl ::
   -> Maybe (LHsExpr GhcPs)       -- observer
   -> Maybe (LHsExpr GhcPs)       -- agreement
   -> Maybe (LHsLocalBinds GhcPs) -- binds
-  -> P ([LHsDecl GhcPs])         -- resulting declaration
+  -> P [LHsDecl GhcPs]         -- resulting declaration
 mkTemplateTemplateInstDecl dataName conName ens sig obs agr binds = do
 { -- Function bindings.
     mbEnsureDecl <- mkTemplateFunBindDecl "ensure" conName ens binds


### PR DESCRIPTION
In this PR the proposed contract key surface syntax (https://github.com/digital-asset/daml/issues/120) . Desugaring has been lightly tested on the ghc side. The resulting `ghc-lib` exhibits no regressions on DAML. Additionally, effort was put into refactoring to reduce code duplication and repetition. Consequently,  this PR adds in total just 33 lines.