### PR TITLE
Implement the TemplateBodyDecls{..} match suggestion

### DIFF
--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3046,7 +3046,7 @@ mkTemplateDecl lname@(L nloc _name) fields (L _ decls) = do
   let dataName = L nloc (HsTyVar noExt NotPromoted lname)
       TemplateBodyDecls {..} = extractTemplateBodyDecls decls
       tbdSignatories' = mergeDecls tbdSignatories
-      tbdObservers' = Just $ allTemplateObservers (mergeDecls tbdObservers) (map (\(L _ pr) -> fst pr) tbdControlledChoiceGroups)
+      tbdObservers' = Just $ allTemplateObservers (mergeDecls tbdObservers) $ map (fst . unLoc) tbdControlledChoiceGroups
       tbdMaintainers' = mergeDecls tbdMaintainers
   checkTemplateDeclConstraints nloc tbdEnsures tbdAgreements tbdLetBindings tbdKeys tbdMaintainers
   let (tbdEnsures', tbdAgreements', tbdLetBindings', tbdKeys') =


### PR DESCRIPTION
This PR implements the change suggested in https://github.com/digital-asset/ghc/pull/10#discussion_r274814003, that is, to use record wild card syntax in a match. Additionally, a tiny utility was factored out to reduce repetition shaving off a few lines. In total, this PR adds -20 lines.