### PR TITLE
Add the Azure CI pipeline for Linux and macOS

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -54,8 +54,8 @@ main = do
 
             cmd "stack build --stack-yaml=hadrian/stack.yaml --only-dependencies --no-terminal --interleaved-output"
             if isWindows
-                then cmdInPythonVenv "hadrian/build.stack.bat --configure --flavour=quickest -j"
-                else cmdInPythonVenv "hadrian/build.stack.sh --configure --flavour=quickest -j"
+                then cmd "hadrian/build.stack.bat --configure --flavour=quickest -j"
+                else cmd "hadrian/build.stack.sh --configure --flavour=quickest -j"
 
             cmd "stack exec --no-terminal -- _build/stage1/bin/ghc --version"
             cmd "git merge --no-edit upstream/da-unit-ids"

--- a/CI.hs
+++ b/CI.hs
@@ -1,0 +1,97 @@
+-- Copyright (c) 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- CI script to build the DA GHC fork and make a ghc-lib out of it
+
+import Control.Monad
+import System.Directory
+import System.Process.Extra
+import System.IO.Extra
+import System.Info.Extra
+import System.Exit
+import System.Time.Extra
+import Data.List.Extra
+import System.Environment
+
+main :: IO ()
+main = do
+    let cmd x = do
+        putStrLn $ "\n\n# Running: " ++ x
+        hFlush stdout
+        (t, _) <- duration $ system_ x
+        putStrLn $ "# Completed in " ++ showDuration t ++ ": " ++ x ++ "\n"
+        hFlush stdout
+    when isWindows $
+        cmd "stack exec -- pacman -S autoconf automake-wrapper make patch python tar --noconfirm"
+
+    let cmdInPythonVenv x = do
+        if isWindows
+            then cmd $ "py -3 -m venv venv && venv\\Scripts\\activate && " ++ x
+            else cmd $ "python3.6 -m venv venv && source venv/bin/activate && " ++ x
+
+    args <- getArgs
+    let featureBranch = args !! 0
+    putStrLn $ "[Info] Git branch name: " ++ featureBranch
+    cmd "git checkout -b da-unit-ids"
+    cmd $ "git checkout -b " ++ featureBranch
+    daGhcDir <- getCurrentDirectory
+
+    cmd "git clone https://github.com/digital-asset/ghc-lib.git"
+    withCurrentDirectory "ghc-lib" $ do
+
+        ghcLibDir <- getCurrentDirectory
+        putStrLn $ "[Info] Entered " ++ ghcLibDir
+        cmd "git clone https://gitlab.haskell.org/ghc/ghc.git"
+
+        withCurrentDirectory "ghc" $ do
+            ghcDir <- getCurrentDirectory
+            putStrLn $ "[Info] Entered " ++ ghcDir
+            cmd $ "git remote add upstream " ++ daGhcDir
+            cmd $ "git fetch upstream da-unit-ids " ++ featureBranch
+            cmd $ "git checkout `git merge-base upstream/" ++ featureBranch ++ " master`"
+            cmd $ "git merge --no-edit upstream/" ++ featureBranch
+            cmd "git submodule update --init --recursive"
+
+            cmd "stack build --stack-yaml=hadrian/stack.yaml --only-dependencies --no-terminal --interleaved-output"
+            if isWindows
+                then cmdInPythonVenv "hadrian/build.stack.bat --configure --flavour=quickest -j"
+                else cmdInPythonVenv "hadrian/build.stack.sh --configure --flavour=quickest -j"
+
+            cmd "stack exec --no-terminal -- _build/stage1/bin/ghc --version"
+            cmd "git merge --no-edit upstream/da-unit-ids"
+
+        cmd "stack setup > /dev/null 2>&1"
+        cmd "stack build --no-terminal --interleaved-output"
+        cmd "stack exec --no-terminal -- ghc-lib-gen ghc --ghc-lib-parser"
+
+        stackYaml <- readFile' "stack.yaml"
+        writeFile "stack.yaml" $ stackYaml ++ unlines ["- ghc"]
+        cmd "stack sdist ghc --tar-dir=."
+        removeFile "ghc/ghc-lib-parser.cabal"
+
+        cmd "cd ghc && git clean -xf && git checkout ."
+        cmd "stack exec --no-terminal -- ghc-lib-gen ghc --ghc-lib"
+        cmd "stack sdist ghc --tar-dir=."
+
+        cmd "tar -xf ghc-lib-parser-0.1.0.tar.gz"
+        cmd "tar -xf ghc-lib-0.1.0.tar.gz"
+        cmd "mv ghc-lib-parser-0.1.0 ghc-lib-parser"
+        cmd "mv ghc-lib-0.1.0 ghc-lib"
+        removeFile "ghc/ghc-lib.cabal"
+
+        writeFile "stack.yaml" $
+           stackYaml ++
+            unlines [ "- ghc-lib-parser"
+                    , "- ghc-lib"
+                    , "- examples/mini-hlint"
+                    , "- examples/mini-compile"
+                    ]
+
+        -- Replace `ghc-prim` with `daml-prim`; this avoids an error importing `GHC.Prim` in MiniCompileTest.hs.
+        cmd "sed -i.bak s/\"ghc-prim\"/\"daml-prim\"/g examples/mini-compile/src/Main.hs"
+
+        cmd "stack build --no-terminal --interleaved-output"
+        cmd "stack exec --no-terminal -- ghc-lib --version"
+        cmd "stack exec --no-terminal -- mini-hlint examples/mini-hlint/test/MiniHlintTest.hs"
+        cmd "stack exec --no-terminal -- mini-hlint examples/mini-hlint/test/MiniHlintTest_error_handling.hs"
+        cmd "stack exec --no-terminal -- mini-compile examples/mini-compile/test/MiniCompileTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -24,11 +24,6 @@ main = do
     when isWindows $
         cmd "stack exec -- pacman -S autoconf automake-wrapper make patch python tar --noconfirm"
 
-    let cmdInPythonVenv x = do
-        if isWindows
-            then cmd $ "py -3 -m venv venv && venv\\Scripts\\activate && " ++ x
-            else cmd $ "python3.6 -m venv venv && source venv/bin/activate && " ++ x
-
     args <- getArgs
     let featureBranch = args !! 0
     putStrLn $ "[Info] Git branch name: " ++ featureBranch

--- a/CI.hs
+++ b/CI.hs
@@ -87,9 +87,6 @@ main = do
                     , "- examples/mini-compile"
                     ]
 
-        -- Replace `ghc-prim` with `daml-prim`; this avoids an error importing `GHC.Prim` in MiniCompileTest.hs.
-        cmd "sed -i.bak s/\"ghc-prim\"/\"daml-prim\"/g examples/mini-compile/src/Main.hs"
-
         cmd "stack build --no-terminal --interleaved-output"
         cmd "stack exec --no-terminal -- ghc-lib --version"
         cmd "stack exec --no-terminal -- mini-hlint examples/mini-hlint/test/MiniHlintTest.hs"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ pr:
 strategy:
   matrix:
     linux:   {image: "Ubuntu 16.04"}
-    windows: {image: "vs2017-win2016"}
+    # windows: {image: "vs2017-win2016"}
     mac:     {image: "macOS-10.13"}
 
 pool: {vmImage: '$(image)'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,39 @@
+trigger:
+  batch: false
+  branches:
+    include:
+    - da-master
+
+# Enable PR triggers that target the master branch
+pr:
+  autoCancel: true # cancel previous builds on push
+  branches:
+    include:
+    - da-master
+
+strategy:
+  matrix:
+    # linux:   {image: "Ubuntu 16.04"}
+    # windows: {image: "vs2017-win2016"}
+    mac:     {image: "macOS-10.13"}
+
+pool: {vmImage: '$(image)'}
+
+steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.6'
+      architecture: 'x64'
+
+  # macOS
+  - bash: |
+      /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+      brew install autoconf automake gmp
+    condition: eq( variables['Agent.OS'], 'Darwin' )
+    displayName: Install brew
+
+
+  - script: |
+      curl -sSL https://get.haskellstack.org/ | sh
+      stack setup --resolver=lts-12.10
+      stack runhaskell CI.hs $(Build.SourceBranchName) --package=extra

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,8 @@ pr:
 
 strategy:
   matrix:
-    # linux:   {image: "Ubuntu 16.04"}
-    # windows: {image: "vs2017-win2016"}
+    linux:   {image: "Ubuntu 16.04"}
+    windows: {image: "vs2017-win2016"}
     mac:     {image: "macOS-10.13"}
 
 pool: {vmImage: '$(image)'}


### PR DESCRIPTION
Adding the Azure pipeline triggered on any PR targeting `da-master` or commits on `da-master`.
The pipeline runs on Linux and macOS.