### PR TITLE
Add some missing cases for record with syntax

### DIFF
--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -2310,6 +2310,9 @@ fielddecls1 :: { [LConDeclField GhcPs] }
         : fielddecl maybe_docnext ',' maybe_docprev fielddecls1
             {% addAnnotation (gl $1) AnnComma (gl $3) >>
                return ((addFieldDoc $1 $4) : addFieldDocs $5 $2) }
+        | fielddecl maybe_docnext ';' maybe_docprev fielddecls1
+            {% addAnnotation (gl $1) AnnComma (gl $3) >>
+               return ((addFieldDoc $1 $4) : addFieldDocs $5 $2) }
         | fielddecl   { [$1] }
 
 fielddecl :: { LConDeclField GhcPs }
@@ -3115,6 +3118,9 @@ fbinds  :: { ([AddAnn],([LHsRecField GhcPs (LHsExpr GhcPs)], Bool)) }
 
 fbinds1 :: { ([AddAnn],([LHsRecField GhcPs (LHsExpr GhcPs)], Bool)) }
         : fbind ',' fbinds1
+                {% addAnnotation (gl $1) AnnComma (gl $2) >>
+                   return (case $3 of (ma,(flds, dd)) -> (ma,($1 : flds, dd))) }
+        | fbind ';' fbinds1
                 {% addAnnotation (gl $1) AnnComma (gl $2) >>
                    return (case $3 of (ma,(flds, dd)) -> (ma,($1 : flds, dd))) }
         | fbind                         { ([],([$1], False)) }

--- a/daml-smoke-tests/Record_with_syntax.hs
+++ b/daml-smoke-tests/Record_with_syntax.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE DamlSyntax #-}
 
-data R = R with foo :: Integer; bar :: String
+data R = R with { foo :: Integer; bar :: String }
+
+data S =
+  S with
+    quux :: Integer
+    corge :: String
 
 updateR :: R -> R
 updateR r =


### PR DESCRIPTION
Recover further adaptions that were missing from the original PR for "record with" syntax.