### PR TITLE
Func ret type sig

### DIFF
--- a/compiler/deSugar/Check.hs
+++ b/compiler/deSugar/Check.hs
@@ -358,6 +358,7 @@ checkGuardMatches hs_ctx guards@(GRHSs _ grhss _) = do
                   Match { m_ext = noExt
                         , m_ctxt = hs_ctx
                         , m_pats = []
+                        , m_rhs_sig = Nothing
                         , m_grhss = guards }
     checkMatches dflags dsMatchContext [] [match]
 checkGuardMatches _ (XGRHSs _) = panic "checkGuardMatches"

--- a/compiler/deSugar/DsMeta.hs
+++ b/compiler/deSugar/DsMeta.hs
@@ -1444,7 +1444,7 @@ repClauseTup (dL->L _ (Match { m_pats = ps
        gs <- repGuards guards
      ; clause <- repClause ps1 gs ds
      ; wrapGenSyms (ss1++ss2) clause }}}
-repClauseTup (dL->L _ (Match _ _ _ (XGRHSs _))) = panic "repClauseTup"
+repClauseTup (dL->L _ (Match _ _ _ _ (XGRHSs _))) = panic "repClauseTup"
 repClauseTup _ = panic "repClauseTup"
 
 repGuards ::  [LGRHS GhcRn (LHsExpr GhcRn)] ->  DsM (Core TH.BodyQ)

--- a/compiler/hsSyn/Convert.hs
+++ b/compiler/hsSyn/Convert.hs
@@ -841,7 +841,7 @@ cvtClause ctxt (Clause ps body wheres)
         ; let pps = map (parenthesizePat appPrec) ps'
         ; g'  <- cvtGuard body
         ; ds' <- cvtLocalDecs (text "a where clause") wheres
-        ; returnL $ Hs.Match noExt ctxt pps (GRHSs noExt g' (noLoc ds')) }
+        ; returnL $ Hs.Match noExt ctxt pps Nothing (GRHSs noExt g' (noLoc ds')) }
 
 cvtImplicitParamBind :: String -> TH.Exp -> CvtM (LIPBind GhcPs)
 cvtImplicitParamBind n e = do
@@ -1125,7 +1125,7 @@ cvtMatch ctxt (TH.Match p body decs)
                      _                    -> p'
         ; g' <- cvtGuard body
         ; decs' <- cvtLocalDecs (text "a where clause") decs
-        ; returnL $ Hs.Match noExt ctxt [lp] (GRHSs noExt g' (noLoc decs')) }
+        ; returnL $ Hs.Match noExt ctxt [lp] Nothing (GRHSs noExt g' (noLoc decs')) }
 
 cvtGuard :: TH.Body -> CvtM [LGRHS GhcPs (LHsExpr GhcPs)]
 cvtGuard (GuardedB pairs) = mapM cvtpair pairs

--- a/compiler/hsSyn/HsUtils.hs
+++ b/compiler/hsSyn/HsUtils.hs
@@ -148,6 +148,7 @@ mkSimpleMatch :: HsMatchContext (NameOrRdrName (IdP (GhcPass p)))
 mkSimpleMatch ctxt pats rhs
   = cL loc $
     Match { m_ext = noExt, m_ctxt = ctxt, m_pats = pats
+          , m_rhs_sig = Nothing
           , m_grhss = unguardedGRHSs rhs }
   where
     loc = case pats of
@@ -859,6 +860,7 @@ mkMatch ctxt pats expr lbinds
   = noLoc (Match { m_ext   = noExt
                  , m_ctxt  = ctxt
                  , m_pats  = map paren pats
+                 , m_rhs_sig = Nothing
                  , m_grhss = GRHSs noExt (unguardedRHS noSrcSpan expr) lbinds })
   where
     paren lp@(dL->L l p)

--- a/compiler/parser/Lexer.x
+++ b/compiler/parser/Lexer.x
@@ -57,7 +57,7 @@ module Lexer (
    activeContext, nextIsEOF,
    getLexState, popLexState, pushLexState,
    ExtBits(..), getBit,
-   damlSyntaxEnabled,
+   damlSyntaxEnabled, scopedTypeVariablesEnabled,
    addWarning,
    lexTokenStream,
    addAnnotation,AddAnn,addAnnsAt,mkParensApiAnn,
@@ -2362,6 +2362,7 @@ data ExtBits
   | MultiWayIfBit
   | GadtSyntaxBit
   | DamlSyntaxBit
+  | ScopedTypeVariablesBit
 
   -- Flags that are updated once parsing starts
   | InRulePragBit
@@ -2375,6 +2376,9 @@ data ExtBits
 
 damlSyntaxEnabled :: ExtsBitmap -> Bool
 damlSyntaxEnabled = xtest DamlSyntaxBit
+
+scopedTypeVariablesEnabled :: ExtsBitmap -> Bool
+scopedTypeVariablesEnabled = xtest ScopedTypeVariablesBit
 
 extension :: (ExtsBitmap -> Bool) -> P Bool
 extension p = P $ \s -> POk s (p $! (pExtsBitmap . options) s)
@@ -2452,6 +2456,7 @@ mkParserFlags' warningFlags extensionFlags thisPackage
       .|. MultiWayIfBit               `xoptBit` LangExt.MultiWayIf
       .|. GadtSyntaxBit               `xoptBit` LangExt.GADTSyntax
       .|. DamlSyntaxBit               `xoptBit` LangExt.DamlSyntax
+      .|. ScopedTypeVariablesBit      `xoptBit` LangExt.ScopedTypeVariables
     optBits =
           HaddockBit        `setBitIf` isHaddock
       .|. RawTokenStreamBit `setBitIf` rawTokStream

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -2713,6 +2713,7 @@ aexp    :: { LHsExpr GhcPs }
                             [sLL $1 $> $ Match { m_ext = noExt
                                                , m_ctxt = LambdaExpr
                                                , m_pats = $2:$3
+                                               , m_rhs_sig = Nothing
                                                , m_grhss = unguardedGRHSs $5 }]))
                           [mj AnnLam $1, mu AnnRarrow $4] }
         | 'let' binds 'in' exp          {% ams (sLL $1 $> $ HsLet noExt (snd $ unLoc $2) $4)
@@ -3050,6 +3051,7 @@ alt     :: { LMatch GhcPs (LHsExpr GhcPs) }
            : pat alt_rhs  {%ams (sLL $1 $> (Match { m_ext = noExt
                                                   , m_ctxt = CaseAlt
                                                   , m_pats = [$1]
+                                                  , m_rhs_sig = Nothing
                                                   , m_grhss = snd $ unLoc $2 }))
                                       (fst $ unLoc $2)}
 

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -114,7 +114,6 @@ import Util
 import ApiAnnotation
 import Data.List
 import DynFlags ( WarningFlag(..) )
-import qualified GHC.LanguageExtensions as LangExt
 import Control.Monad
 import Text.ParserCombinators.ReadP as ReadP
 import Data.Char
@@ -1221,16 +1220,14 @@ checkFunBind :: SDoc
              -> P ([AddAnn],HsBind GhcPs)
 checkFunBind msg strictness ann lhs_loc fun is_infix pats msig (dL->L rhs_span grhss)
   = do
-        pState <- getPState
-{-
-        when (isJust msig && not (extopt LangExt.ScopedTypeVariables (options pState))) $ do
+        scopedTypeVariablesInEffect <- extension scopedTypeVariablesEnabled
+        when (isJust msig && not scopedTypeVariablesInEffect) $ do
              let sig = fromJust msig
                  loc = getLoc (hsSigWcType sig)
              parseErrorSDoc loc
                             (text "Unexpected function return-type annotation:"
                           $$ nest 4 (ppr sig)
                           $$ text "Perhaps you meant to use ScopedTypeVariables?")
--}
 
         ps <- checkPatterns msg pats
         let match_span = combineSrcSpans lhs_loc rhs_span

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -1196,11 +1196,6 @@ checkValDef :: SDoc
             -> Located (a,GRHSs GhcPs (LHsExpr GhcPs))
             -> P ([AddAnn],HsBind GhcPs)
 
-checkValDef msg _strictness lhs (Just sig) grhss
-        -- x :: ty = rhs  parses as a *pattern* binding
-  = checkPatBind msg (cL (combineLocs lhs sig)
-                        (ExprWithTySig noExt lhs (mkLHsSigWcType sig))) grhss
-
 checkValDef msg strictness lhs msig g@(dL->L l (_,grhss))
   = do  { mb_fun <- isFunLhs lhs
   ; case mb_fun of

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -114,7 +114,7 @@ import Util
 import ApiAnnotation
 import Data.List
 import DynFlags ( WarningFlag(..) )
-
+import qualified GHC.LanguageExtensions as LangExt
 import Control.Monad
 import Text.ParserCombinators.ReadP as ReadP
 import Data.Char
@@ -601,6 +601,7 @@ mkPatSynMatchGroup (dL->L loc patsyn_name) (dL->L _ decls) =
            ; match <- case details of
                PrefixCon pats -> return $ Match { m_ext = noExt
                                                 , m_ctxt = ctxt, m_pats = pats
+                                                , m_rhs_sig = Nothing
                                                 , m_grhss = rhs }
                    where
                      ctxt = FunRhs { mc_fun = ln
@@ -610,6 +611,7 @@ mkPatSynMatchGroup (dL->L loc patsyn_name) (dL->L _ decls) =
                InfixCon p1 p2 -> return $ Match { m_ext = noExt
                                                 , m_ctxt = ctxt
                                                 , m_pats = [p1, p2]
+                                                , m_rhs_sig = Nothing
                                                 , m_grhss = rhs }
                    where
                      ctxt = FunRhs { mc_fun = ln
@@ -1199,13 +1201,18 @@ checkValDef msg _strictness lhs (Just sig) grhss
   = checkPatBind msg (cL (combineLocs lhs sig)
                         (ExprWithTySig noExt lhs (mkLHsSigWcType sig))) grhss
 
-checkValDef msg strictness lhs Nothing g@(dL->L l (_,grhss))
+checkValDef msg strictness lhs msig g@(dL->L l (_,grhss))
   = do  { mb_fun <- isFunLhs lhs
-        ; case mb_fun of
-            Just (fun, is_infix, pats, ann) ->
-              checkFunBind msg strictness ann (getLoc lhs)
-                           fun is_infix pats (cL l grhss)
-            Nothing -> checkPatBind msg lhs g }
+  ; case mb_fun of
+      Just (fun, is_infix, pats, ann) ->
+        checkFunBind msg strictness ann (getLoc lhs)
+                    fun is_infix pats (fmap mkLHsSigWcType msig) (cL l grhss)
+      Nothing ->
+        case msig of
+          Nothing  -> checkPatBind msg lhs g
+          -- x :: ty = rhs  parses as a *pattern* binding
+          Just sig -> checkPatBind msg (cL (combineLocs lhs sig)
+                        (ExprWithTySig noExt lhs (mkLHsSigWcType sig))) g }
 
 checkFunBind :: SDoc
              -> SrcStrictness
@@ -1214,10 +1221,23 @@ checkFunBind :: SDoc
              -> Located RdrName
              -> LexicalFixity
              -> [LHsExpr GhcPs]
+             -> Maybe (LHsSigWcType GhcPs)
              -> Located (GRHSs GhcPs (LHsExpr GhcPs))
              -> P ([AddAnn],HsBind GhcPs)
-checkFunBind msg strictness ann lhs_loc fun is_infix pats (dL->L rhs_span grhss)
-  = do  ps <- checkPatterns msg pats
+checkFunBind msg strictness ann lhs_loc fun is_infix pats msig (dL->L rhs_span grhss)
+  = do
+        pState <- getPState
+{-
+        when (isJust msig && not (extopt LangExt.ScopedTypeVariables (options pState))) $ do
+             let sig = fromJust msig
+                 loc = getLoc (hsSigWcType sig)
+             parseErrorSDoc loc
+                            (text "Unexpected function return-type annotation:"
+                          $$ nest 4 (ppr sig)
+                          $$ text "Perhaps you meant to use ScopedTypeVariables?")
+-}
+
+        ps <- checkPatterns msg pats
         let match_span = combineSrcSpans lhs_loc rhs_span
         -- Add back the annotations stripped from any HsPar values in the lhs
         -- mapM_ (\a -> a match_span) ann
@@ -1228,6 +1248,7 @@ checkFunBind msg strictness ann lhs_loc fun is_infix pats (dL->L rhs_span grhss)
                                             , mc_fixity = is_infix
                                             , mc_strictness = strictness }
                                         , m_pats = ps
+                                        , m_rhs_sig = msig
                                         , m_grhss = grhss })])
         -- The span of the match covers the entire equation.
         -- That isn't quite right, but it'll do for now.

--- a/compiler/rename/RnUtils.hs
+++ b/compiler/rename/RnUtils.hs
@@ -411,6 +411,7 @@ data HsDocContext
   | SpliceTypeCtx (LHsType GhcPs)
   | ClassInstanceCtx
   | GenericCtx SDoc   -- Maybe we want to use this more!
+  | MatchRhsSigCtx (Located RdrName)
 
 withHsDocContext :: HsDocContext -> SDoc -> SDoc
 withHsDocContext ctxt doc = doc $$ inHsDocContext ctxt
@@ -437,6 +438,7 @@ pprHsDocContext HsTypeCtx             = text "a type argument"
 pprHsDocContext GHCiCtx               = text "GHCi input"
 pprHsDocContext (SpliceTypeCtx hs_ty) = text "the spliced type" <+> quotes (ppr hs_ty)
 pprHsDocContext ClassInstanceCtx      = text "TcSplice.reifyInstances"
+pprHsDocContext (MatchRhsSigCtx name) = text "a return type for" <+> quotes (ppr name)
 
 pprHsDocContext (ForeignDeclCtx name)
    = text "the foreign declaration for" <+> quotes (ppr name)

--- a/compiler/typecheck/TcArrows.hs
+++ b/compiler/typecheck/TcArrows.hs
@@ -155,8 +155,8 @@ tc_cmd env in_cmd@(HsCmdCase x scrut matches) (stk, res_ty)
   where
     match_ctxt = MC { mc_what = CaseAlt,
                       mc_body = mc_body }
-    mc_body body res_ty' = do { res_ty' <- expTypeToType res_ty'
-                              ; tcCmd env body (stk, res_ty') }
+    mc_body _ body res_ty' = do { res_ty' <- expTypeToType res_ty'
+                                ; tcCmd env body (stk, res_ty') }
 
 tc_cmd env (HsCmdIf x Nothing pred b1 b2) res_ty    -- Ordinary 'if'
   = do  { pred' <- tcMonoExpr pred (mkCheckExpType boolTy)
@@ -256,6 +256,7 @@ tc_cmd env
 
         ; let match' = L mtch_loc (Match { m_ext = noExt
                                          , m_ctxt = LambdaExpr, m_pats = pats'
+                                         , m_rhs_sig = Nothing
                                          , m_grhss = grhss' })
               arg_tys = map hsLPatType pats'
               cmd' = HsCmdLam x (MG { mg_alts = L l [match']

--- a/compiler/typecheck/TcExpr.hs
+++ b/compiler/typecheck/TcExpr.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module TcExpr ( tcPolyExpr, tcMonoExpr, tcMonoExprNC,
+module TcExpr ( tcPolyExpr, tcMonoExpr, tcMonoExprNC, tcExprSig,
                 tcInferSigma, tcInferSigmaNC, tcInferRho, tcInferRhoNC,
                 tcSyntaxOp, tcSyntaxOpGen, SyntaxOpType(..), synKnownType,
                 tcCheckId,
@@ -590,7 +590,7 @@ tcExpr (HsMultiIf _ alts) res_ty
              -- Just like TcMatches
              -- Note [Case branches must never infer a non-tau type]
 
-       ; alts' <- mapM (wrapLocM $ tcGRHS match_ctxt res_ty) alts
+       ; alts' <- mapM (wrapLocM $ tcGRHS match_ctxt res_ty Nothing) alts
        ; res_ty <- readExpType res_ty
        ; return (HsMultiIf res_ty alts') }
   where match_ctxt = MC { mc_what = IfAlt, mc_body = tcBody }

--- a/compiler/typecheck/TcExpr.hs-boot
+++ b/compiler/typecheck/TcExpr.hs-boot
@@ -1,8 +1,8 @@
 module TcExpr where
 import Name
 import HsSyn    ( HsExpr, LHsExpr, SyntaxExpr )
-import TcType   ( TcRhoType, TcSigmaType, SyntaxOpType, ExpType, ExpRhoType )
-import TcRnTypes( TcM, CtOrigin )
+import TcType   ( TcType, TcRhoType, TcSigmaType, SyntaxOpType, ExpType, ExpRhoType )
+import TcRnTypes( TcM, CtOrigin, TcIdSigInfo )
 import HsExtension ( GhcRn, GhcTcId )
 
 tcPolyExpr ::
@@ -39,3 +39,5 @@ tcSyntaxOpGen :: CtOrigin
 
 
 tcCheckId :: Name -> ExpRhoType -> TcM (HsExpr GhcTcId)
+
+tcExprSig :: LHsExpr GhcRn -> TcIdSigInfo -> TcM (LHsExpr GhcTcId, TcType)

--- a/daml-smoke-tests/Test0.hs
+++ b/daml-smoke-tests/Test0.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DamlSyntax #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- Covers:
 --   Version syntax
@@ -20,3 +21,7 @@ updateR r =
   r with
     foo = 1
     bar = "quux"
+
+fact (n : Integer)
+ | n <= 1    = 1
+ | otherwise = n * fact (n - 1)

--- a/daml-smoke-tests/Test0.hs
+++ b/daml-smoke-tests/Test0.hs
@@ -23,6 +23,6 @@ updateR r =
     foo = 1
     bar = "quux"
 
-fact (n : Integer)
+fact (n : Integer) : Integer
  | n <= 1    = 1
  | otherwise = n * fact (n - 1)

--- a/daml-smoke-tests/Test0.hs
+++ b/daml-smoke-tests/Test0.hs
@@ -4,7 +4,8 @@
 -- Covers:
 --   Version syntax
 --   New colon convention
---   Record definition/update
+--   Record "with" definition/update
+--   Function return type annotations
 
 daml 1.2
 module Test0 where


### PR DESCRIPTION
In this PR, we recover function return type annotations e.g.
```haskell
fact (n : Integer)
 | n <= 1    = 1
 | otherwise = n * fact (n - 1)
```
Caution : we may choose not to land this as this patch modifies the parse tree `HsExpr` (additional record field added to a constructor of `data Match`.