### PR TITLE
Support generic templates

### DIFF
--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1164,9 +1164,19 @@ template_decl :: { OrdList (LHsDecl GhcPs) }
 
 -- TODO(RJR): Generalize to multiple constraints
 template_header :: { Located TemplateHeader }
-  : qtycon                                       { sL1 $1 $ TemplateHeader [] $1 [] }
-  | qtycon tyvars                                { sLL $1 $> $ TemplateHeader [] $1 (unLoc $2) }
-  | qtycon tyvars '=>' qtycon tyvars             { sLL $1 $> $ TemplateHeader [sLL $1 $2 $ TemplateConstraint $1 (unLoc $2)] $4 (unLoc $5) }
+  : qtycon                                       { sL1 $1 $ TemplateHeader (noLoc []) $1 [] }
+  | qtycon tyvars                                { sLL $1 $> $ TemplateHeader (noLoc []) $1 (unLoc $2) }
+  | context '=>' qtycon tyvars                   { sLL $1 $> $ TemplateHeader $1 $3 (unLoc $4) }
+  -- | '(' constraints ')' '=>' qtycon tyvars       { sLL $1 $> $ TemplateHeader [] $4 (unLoc $5) }
+
+-- NOTE(RJR): Typeclass constraints are parsed as types elsewhere in the parser,
+-- but we'd like to simplify things and only allow a constrained form for generic templates.
+-- constraints :: { Located [Located TemplateConstraint] }
+  -- : {- empty -}                                  { noLoc [] }
+  -- | constraint constraints                       { sLL $1 $> ($1 : unLoc $2) }
+
+-- constraint :: { Located TemplateConstraint }
+  -- : qtycon tyvars                                { sLL $1 $2 $ TemplateConstraint $1 (unLoc $2) }
 
 -- Type variables (in the order the user wrote)
 tyvars :: { Located [Located RdrName] }

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1159,7 +1159,7 @@ topdecl :: { LHsDecl GhcPs }
 template_decl :: { OrdList (LHsDecl GhcPs) }
   : 'template' template_header arecord_with 'where' template_body
                                                  {% mkTemplateDecls $2 $3 $5 }
-  | 'template' 'instance' qtycon '=' qtycon qtycons
+  | 'template' 'instance' qtycon '=' qtycon arg_types
                                                  {% mkTemplateInstance $3 $5 (unLoc $6) }
 
 template_header :: { Located TemplateHeader }
@@ -1186,9 +1186,9 @@ constraint :: { Located TemplateConstraint }
 tyvars :: { Located [Located RdrName] }
   : varids0                                      { fmap reverse $1 }
 
-qtycons :: { Located [Located RdrName] }
+arg_types :: { Located [LHsType GhcPs] }
   : {- empty -}                                  { noLoc [] }
-  | qtycon qtycons                               { sLL $1 $> ($1 : unLoc $2) }
+  | btype_ arg_types                             { sLL $1 $> ($1 : unLoc $2) }
 
 template_body :: { Located [Located TemplateBodyDecl] }
   : '{' template_body_decls '}'                  { sLL $1 $3 (reverse (unLoc $2)) }

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1164,19 +1164,9 @@ template_decl :: { OrdList (LHsDecl GhcPs) }
 
 -- TODO(RJR): Generalize to multiple constraints
 template_header :: { Located TemplateHeader }
-  : qtycon                                       { sL1 $1 $ TemplateHeader (noLoc []) $1 [] }
-  | qtycon tyvars                                { sLL $1 $> $ TemplateHeader (noLoc []) $1 (unLoc $2) }
-  | context '=>' qtycon tyvars                   { sLL $1 $> $ TemplateHeader $1 $3 (unLoc $4) }
-  -- | '(' constraints ')' '=>' qtycon tyvars       { sLL $1 $> $ TemplateHeader [] $4 (unLoc $5) }
-
--- NOTE(RJR): Typeclass constraints are parsed as types elsewhere in the parser,
--- but we'd like to simplify things and only allow a constrained form for generic templates.
--- constraints :: { Located [Located TemplateConstraint] }
-  -- : {- empty -}                                  { noLoc [] }
-  -- | constraint constraints                       { sLL $1 $> ($1 : unLoc $2) }
-
--- constraint :: { Located TemplateConstraint }
-  -- : qtycon tyvars                                { sLL $1 $2 $ TemplateConstraint $1 (unLoc $2) }
+  : qtycon                                       { sL1 $1 $ TemplateHeader [] $1 [] }
+  | qtycon tyvars                                { sLL $1 $> $ TemplateHeader [] $1 (unLoc $2) }
+  | qtycon tyvars '=>' qtycon tyvars             { sLL $1 $> $ TemplateHeader [sLL $1 $2 $ TemplateConstraint $1 (unLoc $2)] $4 (unLoc $5) }
 
 -- Type variables (in the order the user wrote)
 tyvars :: { Located [Located RdrName] }

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1157,8 +1157,13 @@ topdecl :: { LHsDecl GhcPs }
 -- Templates
 --
 template_decl :: { OrdList (LHsDecl GhcPs) }
-  : 'template' qtycon arecord_with 'where' template_body
+  : 'template' template_header arecord_with 'where' template_body
                                                  {% mkTemplateDecls $2 $3 $5 }
+
+template_header :: { Located TemplateHeader }
+  : qtycon                                       { sL1 $1 $ TemplateHeader [] $1 [] }
+  | qtycon varids0                               { sLL $1 $> $ TemplateHeader [] $1 (unLoc $2) }
+  | qtycon varids0 '=>' qtycon varids0           { sLL $1 $> $ TemplateHeader [sLL $1 $2 $ TemplateConstraint $1 (unLoc $2)] $4 (unLoc $5) }
 
 template_body :: { Located [Located TemplateBodyDecl] }
   : '{' template_body_decls '}'                  { sLL $1 $3 (reverse (unLoc $2)) }

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1163,8 +1163,7 @@ template_decl :: { OrdList (LHsDecl GhcPs) }
                                                  {% mkTemplateInstance $3 $5 (unLoc $6) }
 
 template_header :: { Located TemplateHeader }
-  : qtycon                                       { sL1 $1 $ TemplateHeader [] $1 [] }
-  | qtycon tyvars                                { sLL $1 $> $ TemplateHeader [] $1 (unLoc $2) }
+  : qtycon tyvars                                { sLL $1 $> $ TemplateHeader [] $1 (unLoc $2) }
   | constraint '=>' qtycon tyvars                { sLL $1 $> $ TemplateHeader [$1] $3 (unLoc $4) }
   | '(' constraints ')' '=>' qtycon tyvars       { sLL $1 $> $ TemplateHeader (unLoc $2) $5 (unLoc $6) }
 

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1159,8 +1159,8 @@ topdecl :: { LHsDecl GhcPs }
 template_decl :: { OrdList (LHsDecl GhcPs) }
   : 'template' template_header arecord_with 'where' template_body
                                                  {% mkTemplateDecls $2 $3 $5 }
-  | 'template' 'instance' qtycon '=' qtycon arg_types
-                                                 {% mkTemplateInstance $3 $5 (unLoc $6) }
+  | 'template' 'instance' qtycon '=' btype_      {% mkTemplateInstance $3 $5 }
+    -- ^ parse template application as a single type application
 
 template_header :: { Located TemplateHeader }
   : qtycon tyvars                                { sLL $1 $> $ TemplateHeader [] $1 (unLoc $2) }
@@ -1184,10 +1184,6 @@ constraint :: { Located TemplateConstraint }
 -- Type variables (in the order the user wrote)
 tyvars :: { Located [Located RdrName] }
   : varids0                                      { fmap reverse $1 }
-
-arg_types :: { Located [LHsType GhcPs] }
-  : {- empty -}                                  { noLoc [] }
-  | btype_ arg_types                             { sLL $1 $> ($1 : unLoc $2) }
 
 template_body :: { Located [Located TemplateBodyDecl] }
   : '{' template_body_decls '}'                  { sLL $1 $3 (reverse (unLoc $2)) }

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2468,7 +2468,9 @@ mkTemplateChoiceSigs templateName tyVars ChoiceData{..} =
                              methodName ++ templateName ++ choiceName
       in  noLoc $ ClassOpSig noExt False [fullMethodName] (HsIB noExt ty)
     choiceName = occNameString $ rdrNameOcc $ unLoc cdChoiceName
-    choiceType = mkAppTyVars (rdrNameToType cdChoiceName) tyVars
+    choiceType = case choiceName of
+      "Archive" -> rdrNameToType cdChoiceName
+      _ -> mkAppTyVars (rdrNameToType cdChoiceName) tyVars
     templateType = mkAppTyVars (mkUnqualType templateName) tyVars
     contractId = mkContractId $ mbParenTy templateType
     choiceReturnType = mkUpdate $ mkParenTy cdChoiceReturnTy

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2857,17 +2857,17 @@ mkTemplateDecls (L _ th@(TemplateHeader _ lname@(L nloc name) tyVars)) fields (L
 -- Generate `newtype` and `instance` declarations corresponding to a
 -- `template instance InstanceName = T Arg1 .. ArgN`.
 mkTemplateInstance
-  :: Located RdrName
-  -> Located RdrName
-  -> [Located RdrName]
-  -> P (OrdList (LHsDecl GhcPs))
+  :: Located RdrName              -- ^ Name given to template instance
+  -> Located RdrName              -- ^ Name of generic template
+  -> [LHsType GhcPs]              -- ^ Type arguments to generic template
+  -> P (OrdList (LHsDecl GhcPs))  -- ^ Resulting declarations (`newtype` and `instance` of `TInstance` class)
 mkTemplateInstance instName templateName tyArgs = do
   let templateString = occNameString $ rdrNameOcc $ unLoc templateName
       tInstanceClass = mkUnqualClass $ templateString ++ "Instance"
-      instType = unLoc $ mkAppTyArgs tInstanceClass tyArgs
+      instType = unLoc $ mkHsAppTys tInstanceClass tyArgs
       inst = instDecl $ classInstDecl instType emptyBag
       newTypeCon = L (getLoc instName) $ mkConDeclH98 (rdrNameToDataName instName) Nothing Nothing $
-                     PrefixCon [mkAppTyArgs (rdrNameToType templateName) tyArgs]
+                     PrefixCon [mkHsAppTys (rdrNameToType templateName) tyArgs]
   decl <- mkTyData (getLoc instName) NewType Nothing (noLoc (Nothing, rdrNameToType instName)) Nothing [newTypeCon] (noLoc [])
   let newType = fmap (TyClD noExt) decl
   return $ toOL [newType, inst]

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2639,11 +2639,8 @@ templateConstraintsToContext constraints =
   in  L loc ctx
 
 templateConstraintToType :: TemplateConstraint -> HsType GhcPs
-templateConstraintToType (TemplateConstraint constraint@(L conLoc _) tyVars) =
-  unLoc $ foldl' mkAppWithLocs constraintType $ map rdrNameToType tyVars
-    where
-      mkAppWithLocs ty1@(L l1 _) ty2@(L l2 _) = L (combineSrcSpans l1 l2) (HsAppTy noExt ty1 ty2)
-      constraintType = L conLoc $ HsTyVar NoExt NotPromoted constraint
+templateConstraintToType (TemplateConstraint constraint tyVars) =
+  unLoc $ mkAppTyArgs (rdrNameToType constraint) tyVars
 
 -- | Construct a @class TInstance@.
 mkTemplateInstanceClassDecl ::

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2276,7 +2276,7 @@ partiesType :: LHsType GhcPs
 partiesType = noLoc $ HsListTy noExt $ mkQualType "Party"
 
 mkAppTyArgs :: LHsType GhcPs -> [Located RdrName] -> LHsType GhcPs
-mkAppTyArgs tyCon tyVars = foldl' mkAppTy tyCon $ map rdrNameToType tyVars
+mkAppTyArgs tyCon tyVars = mkHsAppTys tyCon $ map rdrNameToType tyVars
 
 mkTemplateType :: String -> [Located RdrName] -> LHsType GhcPs
 mkTemplateType templateName tyVars = mkAppTyArgs (mkUnqualType templateName) tyVars

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -44,6 +44,7 @@ module   RdrHsSyn (
         TemplateHeader(..),
         TemplateBodyDecl(..),
         mkTemplateDecls,
+        mkTemplateInstance,
         applyToParties,
         applyConcat,
 
@@ -2853,6 +2854,16 @@ mkTemplateDecls (L _ th@(TemplateHeader _ lname@(L nloc name) tyVars)) fields (L
       , ccdFlexible = False
       }
     pureUnit = mkApp (mkUnqualVar $ mkVarOcc "pure") (noLoc $ ExplicitTuple noExt [] Boxed)
+
+-- Generate `newtype` and `instance` declarations corresponding to a
+-- `template instance InstanceName = T Arg1 .. ArgN`.
+mkTemplateInstance
+  :: Located RdrName
+  -> Located RdrName
+  -> [Located RdrName]
+  -> P (OrdList (LHsDecl GhcPs))
+mkTemplateInstance instName templateName tyArgs =
+  return $ toOL []
 
 -----------------------------------------------------------------------------
 -- utilities for foreign declarations

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -40,6 +40,7 @@ module   RdrHsSyn (
         ChoiceConsuming(..),
         FlexChoiceData(..),
         KeyData(..),
+        TemplateConstraint(..),
         TemplateHeader(..),
         TemplateBodyDecl(..),
         mkTemplateDecls,
@@ -2144,13 +2145,13 @@ data KeyData = KeyData {
   , kdMaintainers :: LHsExpr GhcPs
   }
 
-{-data TemplateConstraint = TemplateConstraint {
+data TemplateConstraint = TemplateConstraint {
     tcConstraintName :: Located RdrName
   , tcTypeVars :: [Located RdrName]
-  }-}
+  }
 
 data TemplateHeader = TemplateHeader {
-    thContext :: LHsContext GhcPs
+    thConstraints :: [Located TemplateConstraint]
   , thTemplateName :: Located RdrName
   , thTypeVars :: [Located RdrName]
   }
@@ -2626,7 +2627,7 @@ mkTemplateClassInstanceMethods conName ValidTemplateBody{..} =
                           (mkUnqualVar $ mkVarOcc "cid"))
                         (mkQualVar $ mkDataOcc "Archive")
 
-{-templateConstraintsToContext :: [Located TemplateConstraint] -> LHsContext GhcPs
+templateConstraintsToContext :: [Located TemplateConstraint] -> LHsContext GhcPs
 templateConstraintsToContext constraints =
   let loc = foldl' combineSrcSpans noSrcSpan $ map getLoc constraints
       ctx = map (fmap templateConstraintToType) constraints
@@ -2638,7 +2639,7 @@ templateConstraintToType (TemplateConstraint constraint@(L conLoc _) tyVars) =
     where
       mkAppWithLocs ty1@(L l1 _) ty2@(L l2 _) = L (combineSrcSpans l1 l2) (HsAppTy noExt ty1 ty2)
       constraintType = L conLoc $ HsTyVar NoExt NotPromoted constraint
-      mkTyVar tv@(L tvLoc _) = L tvLoc $ HsTyVar noExt NotPromoted tv-}
+      mkTyVar tv@(L tvLoc _) = L tvLoc $ HsTyVar noExt NotPromoted tv
 
 -- | Construct a @class TInstance@.
 mkTemplateInstanceClassDecl ::
@@ -2650,7 +2651,7 @@ mkTemplateInstanceClassDecl ::
 mkTemplateInstanceClassDecl templateLoc conName TemplateHeader{..} vtb@ValidTemplateBody{..} =
   let templateName = occNameString $ rdrNameOcc $ unLoc conName
       className = L templateLoc $ mkRdrUnqual $ mkClsOcc $ templateName ++ "Instance"
-      -- context = templateConstraintsToContext thConstraints
+      context = templateConstraintsToContext thConstraints
       tyVars = mkHsQTvs $ map rdrNameToTyVar thTypeVars
       keyType = kdKeyType . unLoc <$> vtbKeyData
       templateSigs = mkTemplateClassInstanceSigs templateName thTypeVars keyType
@@ -2659,7 +2660,7 @@ mkTemplateInstanceClassDecl templateLoc conName TemplateHeader{..} vtb@ValidTemp
       choiceMethods = concatMap (mkTemplateChoiceMethods conName vtbLetBindings) vtbChoices
       sigs = templateSigs ++ choiceSigs
       methods = listToBag $ templateMethods ++ choiceMethods
-  in noLoc $ TyClD noExt $ classDecl className thContext tyVars sigs methods
+  in noLoc $ TyClD noExt $ classDecl className context tyVars sigs methods
 
 mkTemplateInstanceMethods ::
      String            -- template name


### PR DESCRIPTION
This change supports compilation of generic templates in Haskell with DAML extensions enabled. Requesting review while I test in DAML proper.