### PR TITLE
Fix parsing of template contexts

### DIFF
--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -2147,7 +2147,7 @@ context :: { LHsContext GhcPs }
                                                 } }
 
 -- Parse a context as a btype_ for DAML template contexts.
--- This is the same as 'context' but does not allow record 'with' types
+-- This is the same as `context` but does not allow record `with` types
 -- which interfere with parsing templates without contexts.
 context_ :: { LHsContext GhcPs }
         :  btype_                       {% do { (anns,ctx) <- checkContext $1

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1216,8 +1216,8 @@ choice_decls :: { Located [Located ChoiceData] }
 
 choice_decl :: { Located ChoiceData }
   : consuming qtycon OF_TYPE btype_ maybe_docprev arecord_with_opt doexp
-      -- NOTE: The use of `btype_` (`btype` excluding record `with` types)
-      -- prevents the choice return type capturing the `with` parameter types.
+      -- NOTE: We use `btype_` (`btype` excluding record `with` types) to
+      -- prevent the choice return type capturing the `with` parameter types.
     { sL (comb3 $1 $2 $>) $
             ChoiceData { cdChoiceName = $2
                        , cdChoiceReturnTy = $4
@@ -1229,8 +1229,8 @@ choice_decl :: { Located ChoiceData }
 
 flex_choice_decl :: { Located FlexChoiceData }
   : consuming 'choice' qtycon OF_TYPE btype_ maybe_docprev arecord_with_opt 'controller' party_list doexp
-      -- NOTE: The use of `btype_` (`btype` excluding record `with` types)
-      -- prevents the choice return type capturing the `with` parameter types.
+      -- NOTE: We use `btype_` (`btype` excluding record `with` types) to
+      -- prevent the choice return type capturing the `with` parameter types.
     { sL (comb3 $1 $2 $>) $
         FlexChoiceData (applyConcat $9)
             ChoiceData { cdChoiceName = $3

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1160,7 +1160,7 @@ template_decl :: { OrdList (LHsDecl GhcPs) }
   : 'template' tycl_hdr_ arecord_with 'where' template_body
                                                  {% mkTemplateDecls (unLoc $2) $3 (unLoc $5) }
   | 'template' 'instance' qtycon '=' btype_      {% mkTemplateInstance $3 $5 }
-    -- ^ parse template application as a single type application
+      -- ^ parse template application as a single type application
 
 template_body :: { Located [Located TemplateBodyDecl] }
   : '{' template_body_decls '}'                  { sLL $1 $3 (reverse (unLoc $2)) }

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1157,19 +1157,10 @@ topdecl :: { LHsDecl GhcPs }
 -- Templates
 --
 template_decl :: { OrdList (LHsDecl GhcPs) }
-  : 'template' template_header arecord_with 'where' template_body
-                                                 {% mkTemplateDecls (unLoc $2) $3 $5 }
+  : 'template' tycl_hdr_ arecord_with 'where' template_body
+                                                 {% mkTemplateDecls (unLoc $2) $3 (unLoc $5) }
   | 'template' 'instance' qtycon '=' btype_      {% mkTemplateInstance $3 $5 }
     -- ^ parse template application as a single type application
-
-template_header :: { Located (Maybe (LHsContext GhcPs), LHsType GhcPs) }
-  : tycl_hdr_                                      { $1 }
-  --: qtycon tyvars                                { sLL $1 $> $ TemplateHeader (noLoc []) $1 (unLoc $2) }
-  --| context_ '=>' qtycon tyvars                  { sLL $1 $> $ TemplateHeader $1 $3 (unLoc $4) }
-
--- Type variables (in the order the user wrote)
-tyvars :: { Located [Located RdrName] }
-  : varids0                                      { fmap reverse $1 }
 
 template_body :: { Located [Located TemplateBodyDecl] }
   : '{' template_body_decls '}'                  { sLL $1 $3 (reverse (unLoc $2)) }

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2874,11 +2874,11 @@ mkArchiveChoice templateName =
 -- called from 'Parser.y').
 mkTemplateDecls
   :: (Maybe (LHsContext GhcPs), LHsType GhcPs)
-                                         -- ^ Template constraints, name and type variables
-  -> LHsType GhcPs                       -- ^ Template parameter record type
-  -> Located [Located TemplateBodyDecl]  -- ^ Template declarations
-  -> P (OrdList (LHsDecl GhcPs))         -- ^ Desugared declarations
-mkTemplateDecls header fields (L _ decls) = do
+                                  -- ^ Template constraints, name and type variables
+  -> LHsType GhcPs                -- ^ Template parameter record type
+  -> [Located TemplateBodyDecl]   -- ^ Template declarations
+  -> P (OrdList (LHsDecl GhcPs))  -- ^ Desugared declarations
+mkTemplateDecls header fields decls = do
   (th@TemplateHeader{..}, vtb@ValidTemplateBody{..}) <- validateTemplateBodyDecls header (extractTemplateBodyDecls decls)
   -- Calculate 'T' data constructor info from 'T' and the record type denoted by 'fields'.
   ci@(conName, _, _) <- splitCon [fields, rdrNameToType thTemplateName]


### PR DESCRIPTION
Previously we parsed a template constraint as a `qtycon` applied to a number of type variables. This is too restrictive as sometimes we want constraints like `Choice t Transfer (ContractId t)`.

This changes context parsing following the way it is done normally in GHC. This requires a slightly modified version of the `context` production which excludes record `with` syntax in types.

We also address Martin's comments from https://github.com/digital-asset/ghc/pull/33#pullrequestreview-275298160.