### PR TITLE
Desugar template instances to type synonyms instead of newtypes

### DIFF
--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2927,11 +2927,11 @@ mkTemplateInstance instName@(L instLoc _) templateApp
   | (templateType, tyArgs) <- splitHsAppTysPs templateApp
   , L _ (HsTyVar NoExt NotPromoted templateName) <- templateType = do
       let instType = unLoc $ mkHsAppTys (mkInstanceClass templateName) tyArgs
-          instDataName = L instLoc $ mkRdrUnqual $ mkDataOcc $ rdrNameToString $ instName
-          newTypeCon = L instLoc $ (mkConDeclH98 instDataName Nothing Nothing $ PrefixCon [templateApp])
-                         { con_doc = Just $ L instLoc $ mkHsDocString "TEMPLATE_INSTANCE" }
-      newTypeDecl <- mkTyData instLoc NewType Nothing (noLoc (Nothing, rdrNameToType instName)) Nothing [newTypeCon] (noLoc [])
-      return $ toOL [TyClD noExt <$> newTypeDecl, instDecl $ classInstDecl instType emptyBag]
+      let tInstanceClass = mkUnqualClass $ mkInstanceClassName . occNameString . rdrNameOcc <$> templateName
+          instType = unLoc $ mkHsAppTys tInstanceClass tyArgs
+          inst = instDecl $ classInstDecl instType emptyBag
+      synDecl <- mkTySynonym instLoc (rdrNameToType instName) templateApp
+      return $ toOL [TyClD noExt <$> synDecl, inst]
   | otherwise = addFatalError instLoc $ text $ rdrNameToString instName ++ " is not an application of a generic template"
 
 -- | Simplified version of splitHsAppTys for splitting a type application

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2930,8 +2930,10 @@ mkTemplateInstance instName@(L instLoc _) templateApp
       let tInstanceClass = mkUnqualClass $ mkInstanceClassName . occNameString . rdrNameOcc <$> templateName
           instType = unLoc $ mkHsAppTys tInstanceClass tyArgs
           inst = instDecl $ classInstDecl instType emptyBag
+          doc = L instLoc $ DocD noExt $ DocCommentNext $ mkHsDocString "TEMPLATE_INSTANCE"
+            -- ^ Marker for DAML-Doc to recognise that a type synonym comes from a template instance
       synDecl <- mkTySynonym instLoc (rdrNameToType instName) templateApp
-      return $ toOL [TyClD noExt <$> synDecl, inst]
+      return $ toOL [doc, TyClD noExt <$> synDecl, inst]
   | otherwise = addFatalError instLoc $ text $ rdrNameToString instName ++ " is not an application of a generic template"
 
 -- | Simplified version of splitHsAppTys for splitting a type application

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2917,23 +2917,32 @@ mkTemplateDecls header fields decls = do
                ++ [templateInstClassDecl] ++ baseInstance ++ [templateInstance]
                ++ choiceInstanceDecls ++ maybeToList keyInstanceDecl
 
--- | Generate `newtype` and `instance` declarations corresponding to a
--- `template instance InstanceName = T Arg1 .. ArgN`.
+-- | Desugar a template instance of the form
+--
+-- @template instance InstanceName = T Arg1 .. ArgN@
+--
+-- to the following:
+--
+-- @-- | TEMPLATE_INSTANCE@
+-- @type InstanceName = T Arg1 .. ArgN@
+-- @instance TInstance Arg1 .. ArgN@
+--
+-- The documentation annotation is needed for damldocs to recognise that the
+-- resulting type synonym corresponds to a template instance.
 mkTemplateInstance
   :: Located RdrName              -- ^ Name given to template instance
   -> LHsType GhcPs                -- ^ Application of generic template to type arguments
-  -> P (OrdList (LHsDecl GhcPs))  -- ^ Resulting declarations (`newtype` and `instance` of `TInstance` class)
+  -> P (OrdList (LHsDecl GhcPs))  -- ^ Resulting `type` (with doc marker) and `instance` declarations
 mkTemplateInstance instName@(L instLoc _) templateApp
   | (templateType, tyArgs) <- splitHsAppTysPs templateApp
-  , L _ (HsTyVar NoExt NotPromoted templateName) <- templateType = do
-      let instType = unLoc $ mkHsAppTys (mkInstanceClass templateName) tyArgs
-      let tInstanceClass = mkUnqualClass $ mkInstanceClassName . occNameString . rdrNameOcc <$> templateName
-          instType = unLoc $ mkHsAppTys tInstanceClass tyArgs
-          inst = instDecl $ classInstDecl instType emptyBag
-          doc = L instLoc $ DocD noExt $ DocCommentNext $ mkHsDocString "TEMPLATE_INSTANCE"
-            -- ^ Marker for DAML-Doc to recognise that a type synonym comes from a template instance
+  , L _ (HsTyVar NoExt NotPromoted templateName) <- templateType
+  = do
       synDecl <- mkTySynonym instLoc (rdrNameToType instName) templateApp
-      return $ toOL [doc, TyClD noExt <$> synDecl, inst]
+      let syn = TyClD noExt <$> synDecl
+          doc = L instLoc $ DocD noExt $ DocCommentNext $ mkHsDocString "TEMPLATE_INSTANCE"
+          instType = unLoc $ mkHsAppTys (mkInstanceClass templateName) tyArgs
+          inst = instDecl $ classInstDecl instType emptyBag
+      return $ toOL [doc, syn, inst]
   | otherwise = addFatalError instLoc $ text $ rdrNameToString instName ++ " is not an application of a generic template"
 
 -- | Simplified version of splitHsAppTys for splitting a type application


### PR DESCRIPTION
* Generate `type` synonym instead of `newtype` for a template instance (along with the `TInstance` type class instance as before)
* Include a doc decl with the string `"TEMPLATE_INSTANCE"` around the template instance decls, for daml-doc to pickup