### PR TITLE
Warn if module name mismatches file name

### DIFF
--- a/compiler/main/DynFlags.hs
+++ b/compiler/main/DynFlags.hs
@@ -837,6 +837,7 @@ data WarningFlag =
    | Opt_WarnImplicitKindVars             -- Since 8.6
    | Opt_WarnSpaceAfterBang
    | Opt_WarnMissingDerivingStrategies    -- Since 8.8
+   | Opt_WarnWrongModuleName
    deriving (Eq, Show, Enum)
 
 data Language = Haskell98 | Haskell2010
@@ -4051,7 +4052,8 @@ wWarningFlagsDeps = [
   flagSpec "star-binder"                 Opt_WarnStarBinder,
   flagSpec "star-is-type"                Opt_WarnStarIsType,
   flagSpec "missing-space-after-bang"    Opt_WarnSpaceAfterBang,
-  flagSpec "partial-fields"              Opt_WarnPartialFields ]
+  flagSpec "partial-fields"              Opt_WarnPartialFields,
+  flagSpec "wrong-module-name"           Opt_WarnWrongModuleName ]
 
 -- | These @-\<blah\>@ flags can all be reversed with @-no-\<blah\>@
 negatableFlagsDeps :: [(Deprecation, FlagSpec GeneralFlag)]
@@ -4763,7 +4765,8 @@ standardWarnings -- see Note [Documenting warning flags]
         Opt_WarnSimplifiableClassConstraints,
         Opt_WarnStarBinder,
         Opt_WarnInaccessibleCode,
-        Opt_WarnSpaceAfterBang
+        Opt_WarnSpaceAfterBang,
+        Opt_WarnWrongModuleName
       ]
 
 -- | Things you get with -W

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -786,15 +786,15 @@ signature :: { Located (HsModule GhcPs) }
 module :: { Located (HsModule GhcPs) }
        : daml_version maybedocheader 'module' modid maybemodwarning maybeexports 'where' body
              {% fileSrcSpan >>= \ loc ->
-                ams (L loc (HsModule (Just $4) $6 (fst $ snd $8)
-                              (snd $ snd $8) $5 $2)
-                    )
+                amms (mkHsModule loc (Just $4) $6 (fst $ snd $8)
+                                 (snd $ snd $8) $5 $2
+                     )
                     ([mj AnnModule $3, mj AnnWhere $7] ++ fst $8) }
         | daml_version body2
                 {% fileSrcSpan >>= \ loc ->
-                   ams (L loc (HsModule Nothing Nothing
-                               (fst $ snd $2) (snd $ snd $2) Nothing Nothing))
-                       (fst $2) }
+                   amms (mkHsModule loc Nothing Nothing
+                                    (fst $ snd $2) (snd $ snd $2) Nothing Nothing)
+                        (fst $2) }
 
 daml_version :: { () }
   : daml version     { ()
@@ -875,16 +875,16 @@ top1    :: { ([LImportDecl GhcPs], [LHsDecl GhcPs]) }
 header  :: { Located (HsModule GhcPs) }
         : daml_version maybedocheader 'module' modid maybemodwarning maybeexports 'where' header_body
                 {% fileSrcSpan >>= \ loc ->
-                   ams (L loc (HsModule (Just $4) $6 $8 [] $5 $2
-                          )) [mj AnnModule $3,mj AnnWhere $7] }
+                   amms (mkHsModule loc (Just $4) $6 $8 [] $5 $2
+                           ) [mj AnnModule $3,mj AnnWhere $7] }
         | maybedocheader 'signature' modid maybemodwarning maybeexports 'where' header_body
                 {% fileSrcSpan >>= \ loc ->
-                   ams (cL loc (HsModule (Just $3) $5 $7 [] $4 $1
-                          )) [mj AnnModule $2,mj AnnWhere $6] }
+                   amms (mkHsModule loc (Just $3) $5 $7 [] $4 $1
+                           ) [mj AnnModule $2,mj AnnWhere $6] }
         | daml_version header_body2
                 {% fileSrcSpan >>= \ loc ->
-                   return (L loc (HsModule Nothing Nothing $2 [] Nothing
-                          Nothing)) }
+                   (mkHsModule loc Nothing Nothing $2 [] Nothing
+                   Nothing) }
 
 header_body :: { [LImportDecl GhcPs] }
         :  '{'            header_top            { $2 }


### PR DESCRIPTION
Implements the `ghc-lib` part of https://github.com/digital-asset/daml/issues/3106

`damlc` will emit a warning of the form
```
Warning: Module names should always match file names, as per [documentation|https://docs.daml.com/daml/reference/file-structure.html]. This rule will be enforced in a future SDK version. Please change the filename to MODULE_NAME.daml in preparation.
```
if the filename of a module does not match its module name.

See https://github.com/digital-asset/daml/pull/3228 for the corresponding changes in the `daml` repository.