### PR TITLE
Adapt template desugaring to split-up template typeclass

### DIFF
--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2563,74 +2563,83 @@ mkChoiceDecls templateLoc conName binds (CombinedChoiceData controllers ChoiceDa
         choiceReturnType = mkUpdate $ mkParenTy cdChoiceReturnTy
         contractIdType = mkContractId templateType
 
-mkTemplateInstanceMethods
-  :: Located RdrName
-  -> ValidTemplate
-  -> [LHsBind GhcPs]   -- ^ method declarations
-mkTemplateInstanceMethods conName ValidTemplate{..} =
-    [ mkMethod "signatory" [this] True vtSignatories
-    , mkMethod "observer" [this] True vtObservers
-    , mkMethod "ensure" [this] True (fromMaybe (mkQualVar $ mkDataOcc "True") vtEnsure)
-    , mkMethod "agreement" [this] True (fromMaybe emptyString vtAgreement)
-    , mkMethod "archive" [cid] False archiveBody
-    ] ++ map (\m -> mkMethod m [] False (mkMagic m)) ["create", "fetch", "toAnyTemplate", "fromAnyTemplate", "_templateTypeRep"]
+emptyString :: LHsExpr GhcPs
+emptyString = noLoc $ HsLit noExt $ HsString NoSourceText $ fsLit ""
+
+
+-- | Construct instances for split-up Template typeclass, i.e., instances for all the single-method typeclasses
+-- that constitute the Template constraint synonym.
+mkTemplateInstanceDecl :: Located String -> Located RdrName -> ValidTemplate -> [LHsDecl GhcPs]
+mkTemplateInstanceDecl templateName conName ValidTemplate{..} =
+  [ signatoryInstance
+  , observerInstance
+  , ensureInstance
+  , agreementInstance
+  , archiveInstance
+  ]
+  ++ emptyInstances
   where
-    this = asPatRecWild "this" conName
-    cid = mkVarPat $ mkVarOcc "cid"
-    emptyString = noLoc $ HsLit noExt $ HsString NoSourceText $ fsLit ""
-    archiveBody = mkApp (mkApp (mkQualVar $ mkVarOcc "exercise")
-                          (mkUnqualVar $ mkVarOcc "cid"))
-                        (mkQualVar $ mkDataOcc "Archive")
+    templateType = mkTemplateType templateName vtTypeVars
+
+    signatoryInstance = mkInstance "HasSignatory" $ mkMethod "signatory" [this] True vtSignatories
+    observerInstance = mkInstance "HasObserver" $ mkMethod "observer" [this] True vtObservers
+    ensureInstance = mkInstance "HasEnsure" $ mkMethod "ensure" [this] True (fromMaybe (mkQualVar $ mkDataOcc "True") vtEnsure)
+    agreementInstance = mkInstance "HasAgreement" $ mkMethod "agreement" [this] True (fromMaybe emptyString vtAgreement)
+    archiveInstance = mkInstance "HasArchive" $ mkMethod "archive" [cid] False $
+      mkApp (mkApp (mkQualVar $ mkVarOcc "exercise") (mkUnqualVar $ mkVarOcc "cid"))
+            (mkQualVar $ mkDataOcc "Archive")
+
+
+    emptyInstances = map mkEmptyInstance ["HasCreate", "HasFetch", "HasToAnyTemplate", "HasFromAnyTemplate", "HasTemplateTypeRep"]
+
+    mkEmptyInstance name =
+        instDecl $ classInstDecl (mkQualClass name `mkAppTy` templateType) emptyBag
+    mkInstance name method =
+        instDecl $ classInstDecl (mkQualClass name `mkAppTy` templateType) $ unitBag method
     mkMethod :: String -> [Pat GhcPs] -> Bool -> LHsExpr GhcPs -> LHsBind GhcPs
     mkMethod methodName args includeBindings methodBody =
       mkTemplateClassMethod methodName args methodBody $
           -- General rule: only include template bindings for methods with `this` in scope
           if includeBindings then Just vtLetBindings else Nothing
+    this = asPatRecWild "this" conName
+    cid = mkVarPat $ mkVarOcc "cid"
 
--- | Construct an @instance TInstance where@
--- and an @instance TInstance => Template T where ...@
-mkTemplateInstanceDecl :: Located String -> Located RdrName -> ValidTemplate -> LHsDecl GhcPs
-mkTemplateInstanceDecl templateName conName vt@ValidTemplate{..} =
-  let templateType = mkTemplateType templateName vtTypeVars
-      templateClass = mkQualClass "Template" `mkAppTy` mbParenTy templateType
-      instanceMethods = listToBag $ mkTemplateInstanceMethods conName vt
-  in  instDecl $ classInstDecl templateClass instanceMethods
-  where
-    mbParenTy = if null vtTypeVars then id else mkParenTy
-
-mkChoiceInstanceDecl :: Located String -> [Located RdrName] -> CombinedChoiceData -> LHsDecl GhcPs
+-- | Construct instances for split-up `Choice` typeclass, i.e., instances for all single-method typeclasses
+-- that constitute the `Choice` constraint synonym.
+mkChoiceInstanceDecl :: Located String -> [Located RdrName] -> CombinedChoiceData -> [LHsDecl GhcPs]
 mkChoiceInstanceDecl templateName tyVars (CombinedChoiceData _ ChoiceData{..} choiceTyVars _) =
-  let templateType = mkTemplateType templateName tyVars
-      choiceType = mkChoiceType cdChoiceName choiceTyVars
-      returnType = mkParenTy cdChoiceReturnTy
-      choiceClass = foldl' mkAppTy (mkQualClass "Choice")
-                      [mbParenTy templateType, mbParenTy choiceType, returnType]
-      mkMethod name prefix =
-        let methodBody = mkMagic (name ++ unLoc templateName ++ rdrNameToString cdChoiceName)
-        in mkTemplateClassMethod (prefix ++ name) [] methodBody Nothing
-      exerciseMethod = mkMethod "exercise" ""
-      toAnyChoiceMethod = mkMethod "toAnyChoice" "_"
-      fromAnyChoiceMethod = mkMethod "fromAnyChoice" "_"
-  in instDecl $ classInstDecl choiceClass $ listToBag [exerciseMethod, toAnyChoiceMethod, fromAnyChoiceMethod]
+  [ mkInstance "HasExercise"
+  , mkInstance "HasToAnyChoice"
+  , mkInstance "HasFromAnyChoice"
+  ]
   where
-    mbParenTy = if null tyVars then id else mkParenTy
+    templateType = mkTemplateType templateName tyVars
+    choiceType = mkChoiceType cdChoiceName choiceTyVars
+    returnType = mkParenTy cdChoiceReturnTy
+    mkClass name = foldl' mkAppTy (mkQualClass name) [templateType, choiceType, returnType]
+    mkInstance name = instDecl $ classInstDecl (mkClass name) emptyBag
 
--- | Create an instance of `TemplateKey`.
-mkKeyInstanceDecl :: Located String -> Located RdrName -> ValidTemplate -> Maybe (LHsDecl GhcPs)
-mkKeyInstanceDecl templateName conName ValidTemplate{..} = do
-  L _ KeyData{..} <- vtKeyData
-  let templateType = mkTemplateType templateName []
-      keyClass = mkQualClass "TemplateKey" `mkAppTy` templateType `mkAppTy` kdKeyType
-      mkMethod :: String -> [Pat GhcPs] -> Bool -> LHsExpr GhcPs -> LHsBind GhcPs
-      mkMethod methodName args includeBindings methodBody =
-       mkTemplateClassMethod methodName args methodBody $
-            -- General rule: only include template bindings for methods with `this` in scope
-           if includeBindings then Just vtLetBindings else Nothing
-      keyMethod = mkMethod "key" [this] True kdKeyExpr
-      maintainerMethod = mkMethod "_maintainer" [proxy, key] False kdMaintainers
-      magicMethods = map (\m -> mkMethod m [] False (mkMagic m)) ["fetchByKey", "lookupByKey", "_toAnyContractKey", "_fromAnyContractKey"]
-      methods = keyMethod : maintainerMethod : magicMethods
-  pure $ instDecl $ classInstDecl keyClass $ listToBag methods
+-- | Construct instances for the split-up `TemplateKey` typeclass, i.e., instances fr all single-method typeclasses
+-- that constitute the `Choice` constraint synonym.
+mkKeyInstanceDecl :: Located String -> Located RdrName -> ValidTemplate -> [LHsDecl GhcPs]
+mkKeyInstanceDecl templateName conName ValidTemplate{..}
+  | Just (L _ KeyData{..}) <- vtKeyData =
+    let templateType = mkTemplateType templateName []
+        mkClass name = mkQualClass name `mkAppTy` templateType `mkAppTy` kdKeyType
+        mkMethod :: String -> [Pat GhcPs] -> Bool -> LHsExpr GhcPs -> LHsBind GhcPs
+        mkMethod methodName args includeBindings methodBody =
+          mkTemplateClassMethod methodName args methodBody $
+           -- General rule: only include template bindings for methods with `this` in scope
+          if includeBindings then Just vtLetBindings else Nothing
+        mkEmptyInstance name = instDecl $ classInstDecl (mkClass name) emptyBag
+        mkInstance name method = instDecl $ classInstDecl (mkClass name) (unitBag method)
+
+        keyInstance = mkInstance "HasKey" $ mkMethod "key" [this] True kdKeyExpr
+        maintainerInstance = mkInstance "HasMaintainer" $ mkMethod "_maintainer" [proxy, key] False kdMaintainers
+    in [ keyInstance
+       , maintainerInstance
+       ] ++ map mkEmptyInstance ["HasFetchByKey", "HasLookupByKey", "HasToAnyContractKey", "HasFromAnyContractKey"]
+  | otherwise = []
   where
     proxy = WildPat noExt
     key = mkVarPat $ mkVarOcc "key"
@@ -2785,12 +2794,12 @@ mkTemplateDecls header fields decls = do
   let templateName = occNameString . rdrNameOcc <$> vtTemplateName
       templateDataDecl = mkTemplateDataDecl (combineLocs vtTemplateName fields) vtTemplateName vtTypeVars ci
       choicesWithArchive = mkArchiveChoice : vtChoices
-      templateInstance = mkTemplateInstanceDecl templateName conName vt
-      choiceInstanceDecls = map (mkChoiceInstanceDecl templateName vtTypeVars) choicesWithArchive
+      templateInstances = mkTemplateInstanceDecl templateName conName vt
+      choiceInstanceDecls = concatMap (mkChoiceInstanceDecl templateName vtTypeVars) choicesWithArchive
       choiceDecls = concatMap (mkChoiceDecls (getLoc templateName) conName vtLetBindings) choicesWithArchive
       keyInstanceDecl = mkKeyInstanceDecl templateName conName vt -- <$> kdKeyType . unLoc <$> vtKeyData
   return $ toOL $ templateDataDecl : choiceDataDecls
-               ++ (templateInstance : choiceInstanceDecls ++ choiceDecls ++ maybeToList keyInstanceDecl)
+               ++ templateInstances ++ (choiceInstanceDecls ++ choiceDecls ++ keyInstanceDecl)
 
 -- | Desugar a template instance of the form
 --


### PR DESCRIPTION
This shouldn’t be merged yet until the new LF conversion is ready but it’s probably a useful reference for implementing the corresponding changes to the LF conversion and testing it. Happy to change the typeclass names to some other scheme.

I’ve just left the instances empty instead of filling in the methods with `mkMagic`. We don’t use the implementation in the LF conversion anyway so we can just add default implementations that call `error`.

As an example, the following DAML template

```
template T
  with
    p : Party
  where
    signatory p
    key p : Party
    maintainer key
```

results in this desugaring

```
data T
  = T {p : Party}
  deriving (DA.Internal.Desugar.Eq, DA.Internal.Desugar.Show)
instance DA.Internal.Desugar.HasSignatory T where
  signatory this@T {..}
    = DA.Internal.Desugar.concat
        [DA.Internal.Desugar.concat [DA.Internal.Desugar.toParties (p)]]
instance DA.Internal.Desugar.HasObserver T where
  observer this@T {..} = DA.Internal.Desugar.concat []
instance DA.Internal.Desugar.HasEnsure T where
  ensure this@T {..} = DA.Internal.Desugar.True
instance DA.Internal.Desugar.HasAgreement T where
  agreement this@T {..} = ""
instance DA.Internal.Desugar.HasArchive T where
  archive cid
    = DA.Internal.Desugar.exercise cid DA.Internal.Desugar.Archive
instance DA.Internal.Desugar.HasCreate T
instance DA.Internal.Desugar.HasFetch T
instance DA.Internal.Desugar.HasToAnyTemplate T
instance DA.Internal.Desugar.HasFromAnyTemplate T
instance DA.Internal.Desugar.HasTemplateTypeRep T
instance DA.Internal.Desugar.HasExercise T DA.Internal.Desugar.Archive (())
instance DA.Internal.Desugar.HasToAnyChoice T DA.Internal.Desugar.Archive (())
instance DA.Internal.Desugar.HasFromAnyChoice T DA.Internal.Desugar.Archive (())
_choice_TArchive :
  (T -> DA.Internal.Desugar.Archive -> [DA.Internal.Desugar.Party],
   DA.Internal.Desugar.ContractId T
   -> T
      -> DA.Internal.Desugar.Archive -> DA.Internal.Desugar.Update (()),
   DA.Internal.Desugar.PreConsuming T)
_choice_TArchive
  = (\ this@T {..} _ -> let in DA.Internal.Desugar.signatory this, 
     \ self this@T {..} arg@DA.Internal.Desugar.Archive
       -> let in pure (), 
     DA.Internal.Desugar.PreConsuming)
instance DA.Internal.Desugar.HasKey T Party where
  key this@T {..} = p
instance DA.Internal.Desugar.HasMaintainer T Party where
  _maintainer _ key
    = DA.Internal.Desugar.concat
        [DA.Internal.Desugar.concat [DA.Internal.Desugar.toParties (key)]]
instance DA.Internal.Desugar.HasFetchByKey T Party
instance DA.Internal.Desugar.HasLookupByKey T Party
instance DA.Internal.Desugar.HasToAnyContractKey T Party
instance DA.Internal.Desugar.HasFromAnyContractKey T Party
```