### PR TITLE
Fix reference to return produced by ApplicativeDo

### DIFF
--- a/compiler/rename/RnExpr.hs
+++ b/compiler/rename/RnExpr.hs
@@ -1713,8 +1713,8 @@ stmtTreeToStmts monad_names ctxt (StmtTreeApplicative trees) tail tail_fvs = do
         if | L _ ApplicativeStmt{} <- last stmts' ->
              return (unLoc tup, emptyNameSet)
            | otherwise -> do
-             (ret,fvs) <- lookupStmtNamePoly ctxt returnMName
-             return (HsApp noExt (noLoc ret) tup, fvs)
+             (ret,fvs) <- lookupStmtName ctxt returnMName
+             return (HsApp noExt (noLoc $ syn_expr ret) tup, fvs)
      return ( ApplicativeArgMany noExt stmts' mb_ret pat
             , fvs1 `plusFV` fvs2)
 


### PR DESCRIPTION
This fixes the issue described at
https://github.com/digital-asset/daml/issues/6820

`lookupStmtNamePoly` calls `getRdrName` on `returnMName` which is the
builtin `return` and then looks for that. However, that produces an
exact (that’s what GHC uses for builtin stuff) `RdrName` so the lookup
will not return what is in scope which it should do with
RebindableSyntax but instead find `GHC.Base.return` which doesn’t
exist. `lookupStmtName` on the other hand produces an unqualified
RdrName `return` and looks for the one that is in scope. This is also
what happens with all other references to `return` at the moment.

This is fixed in GHC 8.10 (although it looks more like it’s fixed by
accident, it’s part of a change to support MonadFail in ApplicativeDo)
so no need to upstream this.