### PR TITLE
Add warning for daml version header

### DIFF
--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -793,7 +793,7 @@ module :: { Located (HsModule GhcPs) }
         | daml_version body2
                 {% fileSrcSpan >>= \ loc ->
                    ams (L loc (HsModule Nothing Nothing
-                               (fst $ snd $2) (snd $ snd $2) Nothing Nothing))
+                               (fst $ snd $2) (snd $ snd $2) Nothing ($1 Nothing)))
                        (fst $2) }
 
 daml_version :: { Maybe LHsDocString -> Maybe LHsDocString }
@@ -871,7 +871,7 @@ top1    :: { ([LImportDecl GhcPs], [LHsDecl GhcPs]) }
 header  :: { Located (HsModule GhcPs) }
         : daml_version maybedocheader 'module' modid maybemodwarning maybeexports 'where' header_body
                 {% fileSrcSpan >>= \ loc ->
-                   ams (L loc (HsModule (Just $4) $6 $8 [] $5 $2
+                   ams (L loc (HsModule (Just $4) $6 $8 [] $5 ($1 $2)
                           )) [mj AnnModule $3,mj AnnWhere $7] }
         | maybedocheader 'signature' modid maybemodwarning maybeexports 'where' header_body
                 {% fileSrcSpan >>= \ loc ->
@@ -880,7 +880,7 @@ header  :: { Located (HsModule GhcPs) }
         | daml_version header_body2
                 {% fileSrcSpan >>= \ loc ->
                    return (L loc (HsModule Nothing Nothing $2 [] Nothing
-                          Nothing)) }
+                          ($1 Nothing))) }
 
 header_body :: { [LImportDecl GhcPs] }
         :  '{'            header_top            { $2 }

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -797,7 +797,9 @@ module :: { Located (HsModule GhcPs) }
                        (fst $2) }
 
 daml_version :: { Maybe LHsDocString }
-  : daml version     { Just (sL1 $1 (mkHsDocString "[HAS_DAML_VERSION_HEADER]")) }
+  : daml version     {% do
+                          loc <- fileSrcSpan
+                          return (Just (L loc (mkHsDocString "[HAS_DAML_VERSION_HEADER]"))) }
   | {- empty  -}     { Nothing }
 
 daml :: { () }

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -36,7 +36,7 @@ import Control.Monad    ( unless, liftM, when, void )
 import GHC.Exts
 import Data.Char
 import Control.Monad    ( mplus )
-import Control.Applicative ((<$))
+import Control.Applicative ((<$), (<|>))
 
 -- compiler/hsSyn
 import HsSyn
@@ -787,7 +787,7 @@ module :: { Located (HsModule GhcPs) }
        : daml_version maybedocheader 'module' modid maybemodwarning maybeexports 'where' body
              {% fileSrcSpan >>= \ loc ->
                 ams (L loc (HsModule (Just $4) $6 (fst $ snd $8)
-                              (snd $ snd $8) $5 $2)
+                              (snd $ snd $8) $5 ($1 <|> $2))
                     )
                     ([mj AnnModule $3, mj AnnWhere $7] ++ fst $8) }
         | daml_version body2
@@ -796,10 +796,9 @@ module :: { Located (HsModule GhcPs) }
                                (fst $ snd $2) (snd $ snd $2) Nothing Nothing))
                        (fst $2) }
 
-daml_version :: { () }
-  : daml version     { () }
-  | {- empty  -}     { () }
-
+daml_version :: { Maybe LHsDocString }
+  : daml version     { Just (sL1 $1 (mkHsDocString "[HAS_DAML_VERSION_HEADER]")) }
+  | {- empty  -}     { Nothing }
 
 daml :: { () }
   : 'daml'           {}


### PR DESCRIPTION
Part of adding a deprecation warning for the `daml 1.2` header. This patch adds a `HAS_DAML_VERSION_HEADER` tag in the `hsmodHaddockModHeader` field of the module, so it can be picked up by damlc. This has been tested and works as expected. See https://github.com/digital-asset/daml/pull/7489 for the counterpart to this patch.