### PR TITLE
Choice observer syntax

### DIFF
--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1216,18 +1216,23 @@ choice_decl :: { Located ChoiceData }
     }
 
 flex_choice_decl :: { Located FlexChoiceData }
-  : consuming 'choice' qtycon OF_TYPE btype_ maybe_docprev arecord_with_opt 'controller' party_list doexp
+  : consuming 'choice' qtycon OF_TYPE btype_ maybe_docprev arecord_with_opt observer_and_controller doexp
       -- NOTE: We use `btype_` (`btype` excluding record `with` types) to
       -- prevent the choice return type capturing the `with` parameter types.
     { sL (comb3 $1 $2 $>) $
-        FlexChoiceData (applyConcat $9)
+        FlexChoiceData (fst $8) (snd $8)
             ChoiceData { cdChoiceName = $3
                        , cdChoiceReturnTy = $5
                        , cdChoiceFields = $7
-                       , cdChoiceBody = $10
+                       , cdChoiceBody = $9
                        , cdChoiceConsuming = $1
                        , cdChoiceDoc = $6 }
     }
+
+observer_and_controller :: { (LHsExpr GhcPs, Maybe (LHsExpr GhcPs)) }
+  : 'controller' party_list { (applyConcat $2, Nothing) }
+  -- we currently only support an optional observer clause *before* the controller clause
+  | 'observer' parties 'controller' party_list  { (applyConcat $4, Just (applyConcat $2)) }
 
 consuming :: { Located (Maybe ChoiceConsuming) }
  : 'preconsuming'                                { sL1 $1 (Just PreConsuming)  }


### PR DESCRIPTION
This PR add syntax for choice observers, and implements their desugaring:


This example shows the existing syntax, and the new choice observer syntax:

```
module ExampleForDesugar where

template TheTemplate
  with
    s : Party
  where
    signatory s

    -- Existing syntax. No choice observers

    choice MyChoice : () with myArgument1 : [Party]
      controller myComputeControllersFrom myArgument1
      do myActionBody


    -- New syntax. choice observers (before controller clause)

    choice MyObservedChoice : () with myArgument2 : [Party]
      observer myComputeObserverFrom myArgument2
      controller myComputeControllersFrom myArgument2
      do myActionBody
```

This is what get generated by the desugaring...

Note. This is out of date. We generate `Optional`/`Some`/`None`, insead of `Maybe`/`Just`/`Nothing` !


No choice observers:
```
_choice_TheTemplateMyChoice :                                               -- HERE, This type is now a 4-tuple
  (TheTemplate -> MyChoice -> [DA.Internal.Desugar.Party],
   DA.Internal.Desugar.ContractId TheTemplate
   -> TheTemplate -> MyChoice -> DA.Internal.Desugar.Update (()),
   DA.Internal.Desugar.Consuming TheTemplate,
   DA.Internal.Desugar.Maybe TheTemplate                                    -- HERE, maybe function type as 4th component.
                             -> MyChoice -> [DA.Internal.Desugar.Party])
_choice_TheTemplateMyChoice
  = (\ this@TheTemplate {..} arg@MyChoice {..}
       -> let
            _ = this
            _ = arg
          in
            DA.Internal.Desugar.concat
              [DA.Internal.Desugar.toParties
                 (myComputeControllersFrom myArgument1)],
     \ self this@TheTemplate {..} arg@MyChoice {..}
       -> let
            _ = self
            _ = this
            _ = arg
          in do myActionBody,
     DA.Internal.Desugar.Consuming, DA.Internal.Desugar.Nothing)            -- HERE, 4th tuple component is Nothing
```

With choice observers:
```
_choice_TheTemplateMyObservedChoice :
  (TheTemplate -> MyObservedChoice -> [DA.Internal.Desugar.Party],
   DA.Internal.Desugar.ContractId TheTemplate
   -> TheTemplate
      -> MyObservedChoice -> DA.Internal.Desugar.Update (()),
   DA.Internal.Desugar.Consuming TheTemplate,
   DA.Internal.Desugar.Maybe TheTemplate                                    -- HERE, same Maybe type
                             -> MyObservedChoice -> [DA.Internal.Desugar.Party])
_choice_TheTemplateMyObservedChoice
  = (\ this@TheTemplate {..} arg@MyObservedChoice {..}
       -> let
            _ = this
            _ = arg
          in
            DA.Internal.Desugar.concat
              [DA.Internal.Desugar.toParties
                 (myComputeControllersFrom myArgument2)],
     \ self this@TheTemplate {..} arg@MyObservedChoice {..}
       -> let
            _ = self
            _ = this
            _ = arg
          in do myActionBody,
     DA.Internal.Desugar.Consuming,
     DA.Internal.Desugar.Just                                               -- HERE, 4th tuple component is Just function
       \ this@TheTemplate {..} arg@MyObservedChoice {..}
         -> let
              _ = this
              _ = arg
            in
              DA.Internal.Desugar.concat
                [DA.Internal.Desugar.toParties
                   (myComputeObserverFrom myArgument2)])
```

(Note, it looks like the PP output from this dump has missed brackets around the `Maybe` and the `Just`)
