### PR TITLE
Don't loose signatures in template let binding

### DIFF
--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2361,8 +2361,8 @@ mkLetBindings :: Bag (LHsBind GhcPs) -> LHsLocalBinds GhcPs
 mkLetBindings binds = noLoc $ HsValBinds noExt (ValBinds noExt binds [])
 -- | Yet more of the -Wunused-matches hack.
 extendLetBindings :: LHsLocalBinds GhcPs -> Bag (LHsBind GhcPs) -> LHsLocalBinds GhcPs
-extendLetBindings (L _ (HsValBinds _ (ValBinds _ orig _))) new =
-  noLoc $ HsValBinds noExt (ValBinds noExt (unionBags orig new) [])
+extendLetBindings (L _ (HsValBinds _ (ValBinds _ orig sigs))) new =
+  noLoc $ HsValBinds noExt (ValBinds noExt (unionBags orig new) sigs)
 extendLetBindings (L _ (EmptyLocalBinds _)) new = mkLetBindings new
 extendLetBindings _ _ = error "unexpected: extendLetBindings"
 


### PR DESCRIPTION
Don't loose signatures in template let binding.

- fix for DAML issue: https://github.com/digital-asset/daml/issues/7902
- PR in daml: https://github.com/digital-asset/daml/pull/8136