### PR TITLE
Start adding exception syntax support.

### DIFF
--- a/compiler/cmm/CmmParse.y
+++ b/compiler/cmm/CmmParse.y
@@ -200,6 +200,8 @@ necessary to the stack to accommodate it (e.g. 2).
 {
 module CmmParse ( parseCmmFile ) where
 
+import qualified Prelude
+
 import GhcPrelude
 
 import StgCmmExtCode
@@ -372,8 +374,8 @@ cmm     :: { CmmParse () }
 cmmtop  :: { CmmParse () }
         : cmmproc                       { $1 }
         | cmmdata                       { $1 }
-        | decl                          { $1 } 
-        | 'CLOSURE' '(' NAME ',' NAME lits ')' ';'  
+        | decl                          { $1 }
+        | 'CLOSURE' '(' NAME ',' NAME lits ')' ';'
                 {% liftP . withThisPackage $ \pkg ->
                    do lits <- sequence $6;
                       staticClosure pkg $3 $5 (map getLit lits) }
@@ -388,30 +390,30 @@ cmmtop  :: { CmmParse () }
 --      * we can derive closure and info table labels from a single NAME
 
 cmmdata :: { CmmParse () }
-        : 'section' STRING '{' data_label statics '}' 
+        : 'section' STRING '{' data_label statics '}'
                 { do lbl <- $4;
                      ss <- sequence $5;
                      code (emitDecl (CmmData (Section (section $2) lbl) (Statics lbl $ concat ss))) }
 
 data_label :: { CmmParse CLabel }
-    : NAME ':'  
+    : NAME ':'
                 {% liftP . withThisPackage $ \pkg ->
                    return (mkCmmDataLabel pkg $1) }
 
 statics :: { [CmmParse [CmmStatic]] }
         : {- empty -}                   { [] }
         | static statics                { $1 : $2 }
-    
+
 static  :: { CmmParse [CmmStatic] }
         : type expr ';' { do e <- $2;
                              return [CmmStaticLit (getLit e)] }
         | type ';'                      { return [CmmUninitialised
                                                         (widthInBytes (typeWidth $1))] }
         | 'bits8' '[' ']' STRING ';'    { return [mkString $4] }
-        | 'bits8' '[' INT ']' ';'       { return [CmmUninitialised 
+        | 'bits8' '[' INT ']' ';'       { return [CmmUninitialised
                                                         (fromIntegral $3)] }
-        | typenot8 '[' INT ']' ';'      { return [CmmUninitialised 
-                                                (widthInBytes (typeWidth $1) * 
+        | typenot8 '[' INT ']' ';'      { return [CmmUninitialised
+                                                (widthInBytes (typeWidth $1) *
                                                         fromIntegral $3)] }
         | 'CLOSURE' '(' NAME lits ')'
                 { do { lits <- sequence $4
@@ -472,7 +474,7 @@ info    :: { CmmParse (CLabel, Maybe CmmInfoTable, [LocalReg]) }
                                            , cit_rep = rep
                                            , cit_prof = prof, cit_srt = Nothing, cit_clo = Nothing },
                               []) }
-        
+
         | 'INFO_TABLE_FUN' '(' NAME ',' INT ',' INT ',' INT ',' STRING ',' STRING ',' INT ')'
                 -- ptrs, nptrs, closure type, description, type, fun type
                 {% liftP . withThisPackage $ \pkg ->
@@ -509,7 +511,7 @@ info    :: { CmmParse (CLabel, Maybe CmmInfoTable, [LocalReg]) }
 
                      -- If profiling is on, this string gets duplicated,
                      -- but that's the way the old code did it we can fix it some other time.
-        
+
         | 'INFO_TABLE_SELECTOR' '(' NAME ',' INT ',' INT ',' STRING ',' STRING ')'
                 -- selector, closure type, description, type
                 {% liftP . withThisPackage $ \pkg ->
@@ -572,7 +574,7 @@ importName
 
         -- A label imported without an explicit packageId.
         --      These are taken to come frome some foreign, unnamed package.
-        : NAME  
+        : NAME
         { ($1, mkForeignLabel $1 Nothing ForeignLabelInExternalPackage IsFunction) }
 
         -- as previous 'NAME', but 'IsData'
@@ -582,8 +584,8 @@ importName
         -- A label imported with an explicit packageId.
         | STRING NAME
         { ($2, mkCmmCodeLabel (fsToUnitId (mkFastString $1)) $2) }
-        
-        
+
+
 names   :: { [FastString] }
         : NAME                          { [$1] }
         | NAME ',' names                { $1 : $3 }
@@ -669,9 +671,9 @@ bool_expr :: { CmmParse BoolExpr }
         | expr                          { do e <- $1; return (BoolTest e) }
 
 bool_op :: { CmmParse BoolExpr }
-        : bool_expr '&&' bool_expr      { do e1 <- $1; e2 <- $3; 
+        : bool_expr '&&' bool_expr      { do e1 <- $1; e2 <- $3;
                                           return (BoolAnd e1 e2) }
-        | bool_expr '||' bool_expr      { do e1 <- $1; e2 <- $3; 
+        | bool_expr '||' bool_expr      { do e1 <- $1; e2 <- $3;
                                           return (BoolOr e1 e2)  }
         | '!' bool_expr                 { do e <- $2; return (BoolNot e) }
         | '(' bool_op ')'               { $2 }
@@ -757,7 +759,7 @@ expr    :: { CmmParse CmmExpr }
 expr0   :: { CmmParse CmmExpr }
         : INT   maybe_ty         { return (CmmLit (CmmInt $1 (typeWidth $2))) }
         | FLOAT maybe_ty         { return (CmmLit (CmmFloat $1 (typeWidth $2))) }
-        | STRING                 { do s <- code (newStringCLit $1); 
+        | STRING                 { do s <- code (newStringCLit $1);
                                       return (CmmLit s) }
         | reg                    { $1 }
         | type '[' expr ']'      { do e <- $3; return (CmmLoad e $1) }
@@ -815,14 +817,14 @@ foreign_formal :: { CmmParse (LocalReg, ForeignHint) }
 local_lreg :: { CmmParse LocalReg }
         : NAME                  { do e <- lookupName $1;
                                      return $
-                                       case e of 
+                                       case e of
                                         CmmReg (CmmLocal r) -> r
                                         other -> pprPanic "CmmParse:" (ftext $1 <> text " not a local register") }
 
 lreg    :: { CmmParse CmmReg }
         : NAME                  { do e <- lookupName $1;
                                      return $
-                                       case e of 
+                                       case e of
                                         CmmReg r -> r
                                         other -> pprPanic "CmmParse:" (ftext $1 <> text " not a register") }
         | GLOBALREG             { return (CmmGlobal $1) }
@@ -1374,7 +1376,7 @@ doSwitch :: Maybe (Integer,Integer)
 doSwitch mb_range scrut arms deflt
    = do
         -- Compile code for the default branch
-        dflt_entry <- 
+        dflt_entry <-
                 case deflt of
                   Nothing -> return Nothing
                   Just e  -> do b <- forkLabelledCode e; return (Just b)

--- a/compiler/parser/Lexer.x
+++ b/compiler/parser/Lexer.x
@@ -896,7 +896,7 @@ reservedWordsFM = listToUFM $
          ( "key",            ITkey,           xbit DamlSyntaxBit),
          ( "maintainer",     ITmaintainer,    xbit DamlSyntaxBit),
          ( "exception",      ITexception,     xbit DamlSyntaxBit),
-         ( "message",        ITmessage,       xbit DamlSyntaxBit),
+         ( "message",        ITmessage,       xbit DamlSyntaxBit)
      ]
 
 {-----------------------------------

--- a/compiler/parser/Lexer.x
+++ b/compiler/parser/Lexer.x
@@ -653,6 +653,8 @@ data Token
   | ITpostconsuming
   | ITkey
   | ITmaintainer
+  | ITexception
+  | ITmessage
 
   -- Pragmas, see  note [Pragma source text] in BasicTypes
   | ITinline_prag       SourceText InlineSpec RuleMatchInfo
@@ -892,7 +894,9 @@ reservedWordsFM = listToUFM $
          ( "preconsuming",   ITpreconsuming,  xbit DamlSyntaxBit),
          ( "postconsuming",  ITpostconsuming, xbit DamlSyntaxBit),
          ( "key",            ITkey,           xbit DamlSyntaxBit),
-         ( "maintainer",     ITmaintainer,    xbit DamlSyntaxBit)
+         ( "maintainer",     ITmaintainer,    xbit DamlSyntaxBit),
+         ( "exception",      ITexception,     xbit DamlSyntaxBit),
+         ( "message",        ITmessage,       xbit DamlSyntaxBit),
      ]
 
 {-----------------------------------

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1156,10 +1156,10 @@ topdecl :: { LHsDecl GhcPs }
 -- Exceptions
 --
 exception_decl :: { OrdList (LHsDecl GhcPs) }
-  : 'exception' tycon arecord_with_opt exception_body_opt {% mkExceptionDecls $2 $3 $4 %}
+  : 'exception' tycon arecord_with_opt exception_body_opt {% mkExceptionDecls $2 $3 $4 }
 
 exception_body_opt :: { [ExceptionBodyDecl] }
-  : 'where' exception_body      { $1 }
+  : 'where' exception_body      { $2 }
   | {- empty -}                 { [] }
 
 exception_body :: { [ExceptionBodyDecl] }
@@ -1173,7 +1173,7 @@ exception_body_decls :: { [ExceptionBodyDecl] }
   | {- empty -}                                    { [] }
 
 exception_body_decl :: { ExceptionBodyDecl }
-  : exception_message_decl                         { MessageDecl $1 }
+  : exception_message_decl                         { ExceptionMessageDecl $1 }
 
 exception_message_decl :: { LHsExpr GhcPs }
   : 'message' exp  { sLL $1 $> $ unLoc $2 }

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2907,7 +2907,7 @@ mkExceptionDataDecl
   -> Located RdrName -- ^ exception name
   -> (Located RdrName, HsConDeclDetails GhcPs, Maybe LHsDocString) -- ^ result of 'splitCon'
   -> LHsDecl GhcPs -- ^ @data@ declaration
-mkExceptionDataDecl srcSpan lname@(L nloc _name) (conName, conDetails, conDoc) =
+mkExceptionDataDecl loc lname@(L nloc _name) (conName, conDetails, conDoc) =
   let conDecl = L nloc $ ConDeclH98
         { con_ext = noExt
         , con_name = conName

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -48,7 +48,7 @@ module   RdrHsSyn (
 
         -- DAML Exception Syntax
         ExceptionBodyDecl(..),
-        mkExceptionDecls
+        mkExceptionDecls,
 
         -- Stuff to do with Foreign declarations
         mkImport,

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2885,7 +2885,7 @@ validateException name ExceptionBodyDecls{..}
         }
   where
     report :: String -> P a
-    report e = addFatalError (getLoc templateApp) (text e)
+    report e = addFatalError (getLoc name) (text e)
 
 -- | Desugar an @exception@ declaration into a list of decls (called from 'Parser.y')
 mkExceptionDecls
@@ -2914,7 +2914,7 @@ mkExceptionInstanceDecls
   :: ValidException
   -> [LHsDecl GhcPs]
 mkExceptionInstanceDecls _
-  = pure [] -- TODO https://github.com/digital-asset/daml/issues/8020
+  = [] -- TODO https://github.com/digital-asset/daml/issues/8020
 
 -- | Desugar a @template@ declaration into a list of decls (this is
 -- called from 'Parser.y').

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2883,6 +2883,9 @@ validateException name ExceptionBodyDecls{..}
         { veName = name
         , veMessage = listToMaybe ebdMessage
         }
+  where
+    report :: String -> P a
+    report e = addFatalError (getLoc templateApp) (text e)
 
 -- | Desugar an @exception@ declaration into a list of decls (called from 'Parser.y')
 mkExceptionDecls

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2228,7 +2228,7 @@ data ValidException = ValidException
   , veMessage :: Maybe (LHsExpr GhcPs) }
 
 data ExceptionBodyDecl
-  = ExceptionMessage (LHsExpr GhcPs)
+  = ExceptionMessageDecl (LHsExpr GhcPs)
 
 data ExceptionBodyDecls = ExceptionBodyDecls
   { ebdMessage :: [LHsExpr GhcPs] }
@@ -2241,7 +2241,7 @@ emptyExceptionBodyDecls = ExceptionBodyDecls []
 
 addExceptionBodyDecl :: ExceptionBodyDecl -> ExceptionBodyDecls -> ExceptionBodyDecls
 addExceptionBodyDecl ebd ebds@ExceptionBodyDecls{..} = case ebd of
-  ExceptionMessage m -> ebds { ebdMessage = m : ebdMessage }
+  ExceptionMessageDecl m -> ebds { ebdMessage = m : ebdMessage }
 
 --------------------------------------------------------------------------------
 -- Utilities for constructing types and values


### PR DESCRIPTION
Counterpart to https://github.com/digital-asset/daml/pull/8960

The point of this PR is to add `exception` syntax support:

```
exception T
  [with
      <record fields>]
  [where
      [message <expr>]]
```

This PR accepts the syntax, and generates the exception data type. I have a test for this in the corresponding PR in the daml repo, [here]( https://github.com/digital-asset/daml/pull/8960/files#diff-b229b8585f27f71034227c38e372335a5ed2a4291771f5fe51c1a718bdfbad90R7).

This PR does not generate the exception instances yet (HasThrow, HasMessage, HasToAnyException, ...), I'm leaving that for the next step. 

(Also, this PR incorporates a patch to CmmParse.y that's needed in the daml repo.)