### PR TITLE
Avoid useless concat calls

### DIFF
--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2369,6 +2369,8 @@ applyToParties p@(L loc _) =
 -- | Calculate the application of 'concat' to a list of expressions
 -- (invoked from Parser.y).
 applyConcat :: Located [LHsExpr GhcPs] -> LHsExpr GhcPs
+applyConcat (L loc []) = L loc $ ExplicitList noExt Nothing []
+applyConcat (L _ [p]) = p
 applyConcat (L loc ps) =
   L loc $ HsApp noExt
     (L loc $ HsVar noExt $ L loc $ qualifyDesugar $ mkVarOcc "concat")


### PR DESCRIPTION
Currently, our signatory definition for a single-party signatory
definition (and observers and other types are very similar) contains
two nested calls to `concat` without any benefit. We can easily
shortcircuit for those examples and save ourselves the overhead of
running through that.

We still have the call to `toParties` but that’s not possible to
remove in the parser, we need to handle this in the simplifier.