### PR TITLE
Drop parser code for generic templates

### DIFF
--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1183,10 +1183,8 @@ exception_message_decl :: { LHsExpr GhcPs }
 -- Templates
 --
 template_decl :: { OrdList (LHsDecl GhcPs) }
-  : 'template' tycl_hdr_ arecord_with 'where' template_body
-                                                 {% mkTemplateDecls (unLoc $2) $3 (unLoc $5) }
-  | 'template' 'instance' qtycon '=' btype_      {% mkTemplateInstance $3 $5 }
-      -- ^ parse template application as a single type application
+  : 'template' tycon arecord_with 'where' template_body
+                                                 {% mkTemplateDecls $2 $3 (unLoc $5) }
 
 template_body :: { Located [Located TemplateBodyDecl] }
   : '{' template_body_decls '}'                  { sLL $1 $3 (reverse (unLoc $2)) }


### PR DESCRIPTION
We initially kept part of that for slightly more reasonable errors
during migration. However, at this point this code no longer serves
any purpose and is just confusing.