### PR TITLE
Fix on macos

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -613,7 +613,7 @@ AC_DEFUN([FP_SET_CFLAGS_C99],
     CPPFLAGS="$$3"
     unset ac_cv_prog_cc_c99
     dnl perform detection
-    _AC_PROG_CC_C99
+    AC_PROG_CC_C99
     fp_cc_c99="$ac_cv_prog_cc_c99"
     case "x$ac_cv_prog_cc_c99" in
       x)   ;; # noop

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -86,6 +86,7 @@ import TysWiredIn       ( unitTyCon, unitDataCon, tupleTyCon, tupleDataCon, nilD
 -- compiler/utils
 import Util             ( looksLikePackageName, fstOf3, sndOf3, thdOf3 )
 import GhcPrelude
+import qualified Prelude
 }
 
 -- %expect 237 -- shift/reduce conflicts


### PR DESCRIPTION
With these two commits I was able to build this repo on macOS with ~~`hadrian/build.stack.sh --configure --flavour=quickest -j`~~ `hadrian/build.stack.sh --configure --flavour=quickest -j --integer-simple`.

The first commit was suggested by @cocreature, so thanks for that!

~~I took the second commit from a "temporary hack" I found on [an issue in the archived hadrian repo](https://github.com/snowleopard/hadrian/issues/493#issuecomment-355877468), so I'm not sure if it's the best solution, or if it will cause any problems on Linux. I'll make a PR to daml to rule out the latter.~~

The second commit simply adds a qualified import of `Prelude` to the `Parser.y` file, since versions of Happy newer than 1.19 apparently don't automatically import the `Prelude`. This was also suggested by @cocreature :)

Finally, I still needed to add the `--integer-simple` flag to get a build on macOS. This is not ideal, but works for now. I've documented the workaround on the Working on `ghc-lib` guide in the corresponding daml PR