### PR TITLE
Pass typerep when calling UExerciseInterface

### DIFF
--- a/DA/Internal/Desugar.hs
+++ b/DA/Internal/Desugar.hs
@@ -104,6 +104,15 @@ class HasToAnyChoice t c r | t c -> r where
 class HasFromAnyChoice t c r | t c -> r where
   _fromAnyChoice : proxy t -> Any -> Optional c
 
+class HasIsInterfaceType t where
+  _isInterfaceType : proxy t -> Bool
+
+_typeRepForInterfaceExercise : (HasTemplateTypeRep t, HasIsInterfaceType t) => proxy t -> Optional TypeRep
+_typeRepForInterfaceExercise p =
+  if _isInterfaceType p
+    then None
+    else Some (_templateTypeRep p)
+
 class HasInterfaceTypeRep i where
   interfaceTypeRep : i -> TypeRep
 

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2870,18 +2870,20 @@ mkInterfaceFixedChoiceInstanceDecl :: Located RdrName -> InterfaceChoiceSignatur
 mkInterfaceFixedChoiceInstanceDecl tycon InterfaceChoiceSignature {..} =
   [ mkInstance "HasToAnyChoice" simpleContext (mkPrimMethod "_toAnyChoice" "EToAnyChoice")
   , mkInstance "HasFromAnyChoice" simpleContext (mkPrimMethod "_fromAnyChoice" "EFromAnyChoice")
-  , mkInstance "HasExercise" exerciseContext (mkTemplateClassMethod "exercise" [cid]
-      ((mkPrimitive "primitive" "UExerciseInterface")
+  , mkInstance "HasExercise" exerciseContext (mkTemplateClassMethod "exercise" [cid, arg]
+      (mkPrimitive "primitive" "UExerciseInterface"
         `mkApp` (mkParExpr $ mkQualVar (mkVarOcc "toInterfaceContractId")
                   `mkAppType` paramType
                   `mkAppType` rdrNameToType tycon
                   `mkApp` mkUnqualVar (mkVarOcc "cid"))
+        `mkApp` (mkUnqualVar (mkVarOcc "arg"))
         `mkApp` (mkParExpr $ mkQualVar (mkVarOcc "_typeRepForInterfaceExercise")
                   `mkApp` mkUnqualVar (mkVarOcc "cid")))
       Nothing)
   ]
   where
     cid = mkVarPat $ mkVarOcc "cid"
+    arg = mkVarPat $ mkVarOcc "arg"
     paramVar = noLoc $ Unqual (mkTyVarOcc "t")
     paramType = noLoc $ HsTyVar noExt NotPromoted paramVar
     implementsConstraint = mkParenTy (mkImplementsConstraint paramType (rdrNameToType tycon))

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2779,7 +2779,7 @@ mkTemplateInstanceDecl sharedBinds templateName conName ValidTemplate{..} =
   , mkInstance "HasToAnyTemplate" $ mkPrimMethod "_toAnyTemplate" "EToAnyTemplate"
   , mkInstance "HasFromAnyTemplate" $ mkPrimMethod "_fromAnyTemplate" "EFromAnyTemplate"
   , mkInstance "HasTemplateTypeRep" $ mkPrimMethod "_templateTypeRep" "ETemplateTypeRep"
-  , mkInstance "HasIsInterfaceType" $ mkTemplateClassMethod methodName [proxy] (mkQualVar $ mkDataOcc "False") Nothing
+  , mkInstance "HasIsInterfaceType" $ mkTemplateClassMethod "_isInterfaceType" [proxy] (mkQualVar $ mkDataOcc "False") Nothing
   ]
   where
     templateType = mkTemplateType templateName

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2779,7 +2779,7 @@ mkTemplateInstanceDecl sharedBinds templateName conName ValidTemplate{..} =
   , mkInstance "HasToAnyTemplate" $ mkPrimMethod "_toAnyTemplate" "EToAnyTemplate"
   , mkInstance "HasFromAnyTemplate" $ mkPrimMethod "_fromAnyTemplate" "EFromAnyTemplate"
   , mkInstance "HasTemplateTypeRep" $ mkPrimMethod "_templateTypeRep" "ETemplateTypeRep"
-  , mkInstance "HasIsInterfaceType" $ mkMethod "_isInterfaceType" [proxy] (mkQualVar $ mkDataOcc "False")
+  , mkInstance "HasIsInterfaceType" $ mkMethod "_isInterfaceType" [proxy] False (mkQualVar $ mkDataOcc "False")
   ]
   where
     templateType = mkTemplateType templateName

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2779,7 +2779,7 @@ mkTemplateInstanceDecl sharedBinds templateName conName ValidTemplate{..} =
   , mkInstance "HasToAnyTemplate" $ mkPrimMethod "_toAnyTemplate" "EToAnyTemplate"
   , mkInstance "HasFromAnyTemplate" $ mkPrimMethod "_fromAnyTemplate" "EFromAnyTemplate"
   , mkInstance "HasTemplateTypeRep" $ mkPrimMethod "_templateTypeRep" "ETemplateTypeRep"
-  , mkInstance "HasIsInterfaceType" $ mkMethod "_isInterfaceType" [proxy] False (mkQualVar $ mkDataOcc "False")
+  , mkInstance "HasIsInterfaceType" $ mkTemplateClassMethod methodName [proxy] (mkQualVar $ mkDataOcc "False") Nothing
   ]
   where
     templateType = mkTemplateType templateName


### PR DESCRIPTION
Added the typeclass `HasIsInterfaceType` so we can detect when
to pass a typerep or when to pass None.

Counterpart to https://github.com/digital-asset/daml/pull/11959