### PR TITLE
implement 'requires' syntax

### DIFF
--- a/DA/Internal/Desugar.hs
+++ b/DA/Internal/Desugar.hs
@@ -150,6 +150,7 @@ fromInterfaceContractId cid = do
     Some (_ : t) -> Some (coerceContractId cid)
 
 data ImplementsT t i = ImplementsT
+data RequiresT a b = RequiresT
 
 class HasMethod i (m : Symbol) r | i m -> r
 

--- a/compiler/parser/Lexer.x
+++ b/compiler/parser/Lexer.x
@@ -637,7 +637,6 @@ data Token
   | ITunit
   | ITsignature
   | ITdependency
-  | ITrequires
 
   | ITdaml
   | ITtemplate

--- a/compiler/parser/Lexer.x
+++ b/compiler/parser/Lexer.x
@@ -659,6 +659,7 @@ data Token
   | ITcatch
   | ITinterface
   | ITimplements
+  | ITrequires
 
   -- Pragmas, see  note [Pragma source text] in BasicTypes
   | ITinline_prag       SourceText InlineSpec RuleMatchInfo
@@ -904,7 +905,8 @@ reservedWordsFM = listToUFM $
          ( "try",            ITtry,           xbit DamlSyntaxBit),
          ( "catch",          ITcatch,         xbit DamlSyntaxBit),
          ( "interface",      ITinterface,     xbit DamlSyntaxBit),
-         ( "implements",     ITimplements,    xbit DamlSyntaxBit)
+         ( "implements",     ITimplements,    xbit DamlSyntaxBit),
+         ( "requires",       ITrequires,      xbit DamlSyntaxBit)
      ]
 
 {-----------------------------------

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1353,7 +1353,7 @@ tyapp_ :: { Located TyEl }
 -- interfaces
 
 interface_decl :: { OrdList (LHsDecl GhcPs) }
-  : 'interface' tycon requires_clause 'where' interface_body {% mkInterfaceDecl $2 $3 (unLoc $4) }
+  : 'interface' tycon requires_clause 'where' interface_body {% mkInterfaceDecl $2 $3 (unLoc $5) }
 
 requires_clause :: { [Located RdrName] }
   : 'requires' requires_list { $2 }

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -525,6 +525,7 @@ are the most common patterns, rewritten as regular expressions for clarity:
  'catch'        { L _ ITcatch }
  'interface'    { L _ ITinterface }
  'implements'   { L _ ITimplements }
+ 'requires'     { L _ ITrequires }
 
  '{-# INLINE'             { L _ (ITinline_prag _ _ _) } -- INLINE or INLINABLE
  '{-# SPECIALISE'         { L _ (ITspec_prag _) }
@@ -1352,7 +1353,18 @@ tyapp_ :: { Located TyEl }
 -- interfaces
 
 interface_decl :: { OrdList (LHsDecl GhcPs) }
-  : 'interface' tycon 'where' interface_body {% mkInterfaceDecl $2 (unLoc $4) }
+  : 'interface' tycon requires_clause 'where' interface_body {% mkInterfaceDecl $2 $3 (unLoc $4) }
+
+requires_clause :: { [Located RdrName] }
+  : 'requires' requires_list { $2 }
+  | {- empty -}              { [] }
+
+requires_list :: { [Located RdrName] }
+  : requires_list_rev { reverse $1 }
+
+requires_list_rev :: { [Located RdrName] }
+  : requires_list_rev ',' qtycon { $3 : $1 }
+  | qtycon { [$1] }
 
 interface_body :: { Located [Located InterfaceBodyDecl] }
 interface_body

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3363,7 +3363,7 @@ mkInterfaceDecl tycon requires decls = do
               (classInstDecl (hasFetch (rdrNameToType tycon))
                  (unitBag (mkPrimMethod "fetch" "UFetchInterface")))]
 
-        requiresMarkers :: [LhsDecl GhcPs]
+        requiresMarkers :: [LHsDecl GhcPs]
         requiresMarkers = concatMap requiresMarker requires
 
         requiresMarker :: Located RdrName -> [LHsDecl GhcPs]

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3363,7 +3363,7 @@ mkInterfaceDecl tycon requires decls = do
               (classInstDecl (hasFetch (rdrNameToType tycon))
                  (unitBag (mkPrimMethod "fetch" "UFetchInterface")))]
 
-        requiresMarkers :: [LhsDeclGhcPs]
+        requiresMarkers :: [LhsDecl GhcPs]
         requiresMarkers = concatMap requiresMarker requires
 
         requiresMarker :: Located RdrName -> [LHsDecl GhcPs]

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3415,7 +3415,7 @@ mkInterfaceDecl tycon requires decls = do
 
         requiresInstances :: [LHsDecl GhcPs]
         requiresInstances = concat
-          [ mkRequiredImplementsInstances iface (rdrNameToType requiredTycon)
+          [ mkRequiredImplementsInstances ifaceTy (rdrNameToType requiredTycon)
           | requiredTycon <- requires
           ]
 

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3417,7 +3417,7 @@ mkInterfaceDecl tycon requires decls = do
         requiresInstances = concat
           [ mkRequiredImplementsInstances ifaceTy (rdrNameToType requiredTycon)
           | requiredTycon <- requires
-          , requiredTycon /= tycon
+          , unLoc requiredTycon /= unLoc tycon
               -- NOTE (Sofia): Circular requirement (self-requirement) is an error, but
               -- we don't want it to turn into a "duplicate instance" error in the
               -- GHC typechecker. We want the circular requirement to be visible

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3417,6 +3417,13 @@ mkInterfaceDecl tycon requires decls = do
         requiresInstances = concat
           [ mkRequiredImplementsInstances ifaceTy (rdrNameToType requiredTycon)
           | requiredTycon <- requires
+          , requiredTycon /= tycon
+              -- NOTE (Sofia): Circular requirement (self-requirement) is an error, but
+              -- we don't want it to turn into a "duplicate instance" error in the
+              -- GHC typechecker. We want the circular requirement to be visible
+              -- to damlc so that we can generate nicer error messages. That's why
+              -- we don't generate an instance if tycon == requiredTycon, since it
+              -- conflicts with the usual "HasToInterface iface iface" instance.
           ]
 
         ifaceMethods :: [LHsDecl GhcPs]

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3370,7 +3370,7 @@ mkInterfaceDecl tycon requires decls = do
         requiresMarker requiredTycon =
             let name =
                   mkRdrUnqual $ mkVarOcc $ concat
-                    [ "_requires_", rdrNameToString tycon,
+                    [ "_requires_", rdrNameToString tycon
                     , "_", rdrNameToString requiredTycon ]
                 sig =
                   TypeSig noExt [noLoc name] $


### PR DESCRIPTION
daml PR: https://github.com/digital-asset/daml/pull/12105

this PR:

- adds `require` syntax (see daml PR for examples)
- adds HasToInterface and HasFromInterface instances for require
- changes the `HasToInterface iface iface` and `HasFromInterface iface iface` instances to be directly implemented, instead of relying on disambiguation in a damlc primitive 