### PR TITLE
Drop typerep arg in interface exercise.

### DIFF
--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3000,10 +3000,9 @@ mkInterfaceFixedChoiceInstanceDecl tycon InterfaceChoiceSignature {..} =
                     `mkAppType` ifaceType
                     `mkApp` mkUnqualVar (mkVarOcc "cid"))
           `mkApp` (mkUnqualVar (mkVarOcc "arg"))
-          `mkApp` (mkParExpr $ mkQualVar (mkVarOcc "_typeRepForInterfaceExercise")
-                    `mkApp` mkUnqualVar (mkVarOcc "cid"))
           `mkApp` (mkParExpr $ mkQualVar (mkVarOcc "_exerciseInterfaceGuard")
                     `mkAppType` ifaceType
+                    `mkApp` mkUnqualVar (mkVarOcc "cid")
                     `mkApp` mkUnqualVar (mkVarOcc "pred")))
         Nothing)
   , mkInstance "HasExercise"


### PR DESCRIPTION
And pass the contract id to the guard, so we can generate a nicer error.