### PR TITLE
Add changes required by DAML

### DIFF
--- a/compiler/basicTypes/Module.hs
+++ b/compiler/basicTypes/Module.hs
@@ -1088,10 +1088,10 @@ See Note [The integer library] in PrelNames.
 integerUnitId, primUnitId,
   baseUnitId, rtsUnitId,
   thUnitId, mainUnitId, thisGhcUnitId, interactiveUnitId  :: UnitId
-primUnitId        = fsToUnitId (fsLit "ghc-prim")
-integerUnitId     = fsToUnitId (fsLit "integer-wired-in")
+primUnitId        = fsToUnitId (fsLit "daml-prim")
+integerUnitId     = primUnitId
    -- See Note [The integer library] in PrelNames
-baseUnitId        = fsToUnitId (fsLit "base")
+baseUnitId        = primUnitId
 rtsUnitId         = fsToUnitId (fsLit "rts")
 thUnitId          = fsToUnitId (fsLit "template-haskell")
 thisGhcUnitId     = fsToUnitId (fsLit "ghc")

--- a/hadrian/hadrian.cabal
+++ b/hadrian/hadrian.cabal
@@ -115,19 +115,19 @@ executable hadrian
                        , TupleSections
     other-extensions:    MultiParamTypeClasses
                        , TypeFamilies
-    build-depends:       base                 >= 4.8     && < 5
-                       , Cabal                >= 3.0     && < 3.1
-                       , containers           >= 0.5     && < 0.7
-                       , directory            >= 1.2     && < 1.4
-                       , extra                >= 1.4.7
-                       , mtl                  == 2.2.*
-                       , parsec               >= 3.1     && < 3.2
-                       , QuickCheck           >= 2.6     && < 2.14
-                       , shake                >= 0.16.4
-                       , transformers         >= 0.4     && < 0.6
-                       , unordered-containers >= 0.2.1   && < 0.3
-    build-tools:         alex  >= 3.1
-                       , happy >= 1.19.4
+    build-depends:       base
+                       , Cabal
+                       , containers
+                       , directory
+                       , extra
+                       , mtl
+                       , parsec
+                       , QuickCheck
+                       , shake
+                       , transformers
+                       , unordered-containers
+    build-tools:         alex
+                       , happy
     ghc-options:       -Wall
                        -Wincomplete-record-updates
                        -Wredundant-constraints

--- a/hadrian/src/Hadrian/Haskell/Cabal/Parse.hs
+++ b/hadrian/src/Hadrian/Haskell/Cabal/Parse.hs
@@ -38,6 +38,7 @@ import qualified Distribution.Text                             as C
 import qualified Distribution.Types.LocalBuildInfo             as C
 import qualified Distribution.Types.CondTree                   as C
 import qualified Distribution.Types.MungedPackageId            as C
+import qualified Distribution.Utils.ShortText                  as C
 import qualified Distribution.Verbosity                        as C
 import Hadrian.Expression
 import Hadrian.Haskell.Cabal
@@ -67,7 +68,7 @@ parsePackageData pkg = do
         sorted  = sort [ C.unPackageName p | C.Dependency p _ _ <- allDeps ]
         deps    = nubOrd sorted \\ [name]
         depPkgs = catMaybes $ map findPackageByName deps
-    return $ PackageData name version (C.synopsis pd) (C.description pd) depPkgs gpd
+    return $ PackageData name version (C.fromShortText $ C.synopsis pd) (C.fromShortText $ C.description pd) depPkgs gpd
   where
     -- Collect an overapproximation of dependencies by ignoring conditionals
     collectDeps :: Maybe (C.CondTree v [C.Dependency] a) -> [C.Dependency]

--- a/hadrian/src/Hadrian/Haskell/Cabal/Type.hs
+++ b/hadrian/src/Hadrian/Haskell/Cabal/Type.hs
@@ -12,7 +12,7 @@
 module Hadrian.Haskell.Cabal.Type where
 
 import Development.Shake.Classes
-import Distribution.PackageDescription
+import Distribution.PackageDescription hiding (PackageName)
 import GHC.Generics
 
 import Hadrian.Package


### PR DESCRIPTION
Daml PR: https://github.com/digital-asset/daml/pull/12508

These two patches are required when building `ghc-lib{,parser}` with Bazel from the DAML project.

1. https://github.com/digital-asset/daml/blob/c1847f0715c12720481eda4161e9f6945a5f8da0/bazel_tools/ghc-lib/ghc-daml-prim.patch
2. https://github.com/digital-asset/daml/blob/c1847f0715c12720481eda4161e9f6945a5f8da0/bazel_tools/ghc-lib/ghc-hadrian.patch

Instead of maintaining these patches in the DAML project, and having to manually add them to a local checkout of this project each time you want to integrate / test changes in DAML, these patches are added here.

The downside of it is that you are no longer able to build Hadrian and hence this fork locally when you just check it out.

## Context

- `ghc-daml-prim.patch` rename `ghc-prim` to `daml-prim`
    Patch generated with
    ```
    BASE=da-master-8.8.1
    git clone https://github.com/digital-asset/ghc.git
    cd ghc
    git checkout $BASE
    git merge --no-edit 833ca63be2ab14871874ccb6974921e8952802e
    git diff $BASE
    ```
- `ghc-hadrian.patch` patch Hadrian to build with the more recent GHC version
    used by the Daml repository. The patch is generated manually be removing
    all version constraints from Hadrian's Cabal file and changing the
    implementation to fix any GHC compiler errors.
