### PR TITLE
Make building in-project and with Bazel work again

### DIFF
--- a/hadrian/hadrian.cabal
+++ b/hadrian/hadrian.cabal
@@ -14,6 +14,10 @@ source-repository head
     type:     git
     location: https://github.com/snowleopard/hadrian
 
+flag with_bazel
+  description: Build with Bazel
+  default: False
+
 executable hadrian
     main-is:             Main.hs
     hs-source-dirs:      .
@@ -115,19 +119,34 @@ executable hadrian
                        , TupleSections
     other-extensions:    MultiParamTypeClasses
                        , TypeFamilies
-    build-depends:       base
-                       , Cabal
-                       , containers
-                       , directory
-                       , extra
-                       , mtl
-                       , parsec
-                       , QuickCheck
-                       , shake
-                       , transformers
-                       , unordered-containers
-    build-tools:         alex
-                       , happy
+    if flag(with_bazel)
+        build-depends:       base
+                           , Cabal
+                           , containers
+                           , directory
+                           , extra
+                           , mtl
+                           , parsec
+                           , QuickCheck
+                           , shake
+                           , transformers
+                           , unordered-containers
+        build-tools:         alex
+                           , happy
+    else
+        build-depends:       base                 >= 4.8     && < 5
+                           , Cabal                >= 3.0     && < 3.1
+                           , containers           >= 0.5     && < 0.7
+                           , directory            >= 1.2     && < 1.4
+                           , extra                >= 1.4.7
+                           , mtl                  == 2.2.*
+                           , parsec               >= 3.1     && < 3.2
+                           , QuickCheck           >= 2.6     && < 2.14
+                           , shake                >= 0.16.4
+                           , transformers         >= 0.4     && < 0.6
+                           , unordered-containers >= 0.2.1   && < 0.3
+        build-tools:         alex  >= 3.1
+                           , happy >= 1.19.4
     ghc-options:       -Wall
                        -Wincomplete-record-updates
                        -Wredundant-constraints

--- a/hadrian/hadrian.cabal
+++ b/hadrian/hadrian.cabal
@@ -133,6 +133,7 @@ executable hadrian
                            , unordered-containers
         build-tools:         alex
                            , happy
+        cpp-options:       -DWITH_BAZEL
     else
         build-depends:       base                 >= 4.8     && < 5
                            , Cabal                >= 3.0     && < 3.1

--- a/hadrian/src/Hadrian/Haskell/Cabal/Parse.hs
+++ b/hadrian/src/Hadrian/Haskell/Cabal/Parse.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module     : Hadrian.Haskell.Cabal.Parse
@@ -38,7 +39,9 @@ import qualified Distribution.Text                             as C
 import qualified Distribution.Types.LocalBuildInfo             as C
 import qualified Distribution.Types.CondTree                   as C
 import qualified Distribution.Types.MungedPackageId            as C
+#ifdef WITH_BAZEL
 import qualified Distribution.Utils.ShortText                  as C
+#endif
 import qualified Distribution.Verbosity                        as C
 import Hadrian.Expression
 import Hadrian.Haskell.Cabal
@@ -68,7 +71,11 @@ parsePackageData pkg = do
         sorted  = sort [ C.unPackageName p | C.Dependency p _ _ <- allDeps ]
         deps    = nubOrd sorted \\ [name]
         depPkgs = catMaybes $ map findPackageByName deps
+#ifdef WITH_BAZEL
     return $ PackageData name version (C.fromShortText $ C.synopsis pd) (C.fromShortText $ C.description pd) depPkgs gpd
+#else
+    return $ PackageData name version (C.synopsis pd) (C.description pd) depPkgs gpd
+#endif
   where
     -- Collect an overapproximation of dependencies by ignoring conditionals
     collectDeps :: Maybe (C.CondTree v [C.Dependency] a) -> [C.Dependency]


### PR DESCRIPTION
DAML PR: https://github.com/digital-asset/daml/pull/13970

# Purpose

Currently, the CI job in ghc-lib does not work anymore integrating da-ghc-8.8.1 due to the changes of https://github.com/digital-asset/daml/pull/12508.

Also, building ghc itself using hadrian, and then running `./_build/stage1/bin/ghc` on some example `.daml` file is no longer possible.

This change is part one of the fix.

# Follow-ups

- [x] after merging this PR, update the `GHC_REV` variable in the daml repository
- [x] re-enable ghc-lib CI jobs (https://github.com/digital-asset/ghc-lib/pull/370/commits/cd025639ff9a7fac6e00ab253ddde4cdf949e310#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L177-R196)

cc @remyhaemmerle-da 