### PR TITLE
Add flag for daml-specific remapping of wired-in package ids

### DIFF
--- a/compiler/basicTypes/Module.hs
+++ b/compiler/basicTypes/Module.hs
@@ -9,6 +9,7 @@ These are Uniquable, hence we can build Maps with Modules as
 the keys.
 -}
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
@@ -1088,10 +1089,16 @@ See Note [The integer library] in PrelNames.
 integerUnitId, primUnitId,
   baseUnitId, rtsUnitId,
   thUnitId, mainUnitId, thisGhcUnitId, interactiveUnitId  :: UnitId
+#ifdef DAML_PRIM
 primUnitId        = fsToUnitId (fsLit "daml-prim")
 integerUnitId     = primUnitId
-   -- See Note [The integer library] in PrelNames
 baseUnitId        = primUnitId
+#else
+primUnitId        = fsToUnitId (fsLit "ghc-prim")
+integerUnitId     = fsToUnitId (fsLit "integer-wired-in")
+   -- See Note [The integer library] in PrelNames
+baseUnitId        = fsToUnitId (fsLit "base")
+#endif
 rtsUnitId         = fsToUnitId (fsLit "rts")
 thUnitId          = fsToUnitId (fsLit "template-haskell")
 thisGhcUnitId     = fsToUnitId (fsLit "ghc")

--- a/compiler/ghc.cabal.in
+++ b/compiler/ghc.cabal.in
@@ -55,6 +55,11 @@ Flag integer-gmp
     Manual: True
     Default: False
 
+Flag daml-prim
+    Description: Use 'daml-prim' as the unit id for 'ghc-prim', 'integer-wired-in' and 'base'
+    Manual: True
+    Default: False
+
 Library
     Default-Language: Haskell2010
     Exposed: False
@@ -106,6 +111,9 @@ Library
     if flag(integer-simple)
         CPP-Options: -DINTEGER_SIMPLE
         build-depends: integer-simple >= 0.1.1.1
+
+    if flag(daml-prim)
+        CPP-Options: -DDAML_PRIM
 
     Other-Extensions:
         BangPatterns


### PR DESCRIPTION
ghc-lib PR: https://github.com/digital-asset/ghc-lib/pull/377
da-ghc PR: (here)
daml PR: https://github.com/digital-asset/daml/pull/14074

Essentially, this puts the fix from 7d268d0b648fbe92768c47605581788cf7a61625 behind a cabal flag/cpp option