### PR TITLE
Make source location of ImplementsT point to `implements` keyword

### DIFF
--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1221,7 +1221,7 @@ let_bindings_decl :: { Located ([AddAnn], LHsLocalBinds GhcPs) }
                                              , snd $ unLoc $2) }
 
 implements_group_decl :: { Located ParsedImplementsDeclBlock }
-  : 'implements' qtycon where_impl { sL1 $1 $ ParsedImplementsDeclBlock $2 $3 }
+  : 'implements' qtycon where_impl { sLL $1 $2 $ ParsedImplementsDeclBlock $2 $3 }
 
 where_impl :: { [LHsDecl GhcPs] }
   : where_inst { fromOL (snd (unLoc $1)) }


### PR DESCRIPTION
We use this to improve the error message when implementing non-interfaces:
https://github.com/digital-asset/daml/issues/13823
https://github.com/digital-asset/daml/pull/14249

CHANGELOG_BEGIN
CHANGELOG_END