### PR TITLE
Add `interface instance` syntax, including retroactive interface instances

### DIFF
--- a/DA/Internal/Desugar.hs
+++ b/DA/Internal/Desugar.hs
@@ -154,7 +154,7 @@ class HasFromInterface t i where
   fromInterface : i -> Optional t
   unsafeFromInterface : ContractId i -> i -> t
 
-class HasInterfaceView i v | i -> v
+class HasInterfaceView i v | i -> v where
   _view : i -> v
 
 newtype InterfaceView t i = InterfaceView ()

--- a/DA/Internal/Desugar.hs
+++ b/DA/Internal/Desugar.hs
@@ -193,6 +193,11 @@ _exerciseInterfaceGuard pred iface =
 
 -- ## Interface instance markers
 
+-- | The type arguments @p@, @i@ and @t@ refer, respectively, to the
+-- parent, interface and template of this interface instance. The parent
+-- is the type whose declaration contains the interface instance, and must match
+-- either the interface or the template. This is checked in RdrHsSyn and again
+-- during LF Conversion.
 newtype InterfaceInstance p i t = InterfaceInstance ()
 
 mkInterfaceInstance : forall p i t. InterfaceInstance p i t
@@ -202,6 +207,8 @@ mkInterfaceInstance = InterfaceInstance ()
 
 class HasMethod i (m : Symbol) r | i m -> r
 
+-- | The type arguments @p@, @i@ and @t@ are the same as in 'InterfaceInstance',
+-- while @m@ is the name of the method represented as a 'Symbol'.
 newtype Method p i t (m : Symbol) = Method ()
 
 mkMethod : forall p i t m r. (Implements t i, HasMethod i m r) => (t -> r) -> Method p i t m
@@ -212,6 +219,7 @@ mkMethod _ = Method ()
 -- class HasInterfaceView is also used for the type of the `view` function,
 -- so it's not here.
 
+-- | The type arguments @p@, @i@ and @t@ are the same as in 'InterfaceInstance'.
 newtype InterfaceView p i t = InterfaceView ()
 
 mkInterfaceView : forall p i t v. (Implements t i, HasInterfaceView i v) => (t -> v) -> InterfaceView p i t

--- a/DA/Internal/Desugar.hs
+++ b/DA/Internal/Desugar.hs
@@ -191,7 +191,7 @@ _exerciseInterfaceGuard pred iface =
 --------------------------------------------------------------------------------
 -- # Interface instance desugaring
 
--- ## Implements markers
+-- ## Interface instance markers
 
 newtype InterfaceInstance p i t = InterfaceInstance ()
 

--- a/Example.hs
+++ b/Example.hs
@@ -37,6 +37,14 @@ template TheTemplate
       controller s
       do return ()
 
-    implements TheInterface where
+    interface instance TheInterface for TheTemplate where
       myInternalValue = 1000
       view = myInternalValue this * 1000
+
+interface AnotherInterface where
+  someBool : Bool
+  viewtype Ordering
+
+  interface instance AnotherInterface for TheTemplate where
+    someBool = False
+    view = if someBool this then GT else LT

--- a/compiler/parser/Lexer.x
+++ b/compiler/parser/Lexer.x
@@ -657,7 +657,7 @@ data Token
   | ITtry
   | ITcatch
   | ITinterface
-  | ITimplements
+  | ITfor
   | ITrequires
   | ITviewtype
 
@@ -905,7 +905,7 @@ reservedWordsFM = listToUFM $
          ( "try",            ITtry,           xbit DamlSyntaxBit),
          ( "catch",          ITcatch,         xbit DamlSyntaxBit),
          ( "interface",      ITinterface,     xbit DamlSyntaxBit),
-         ( "implements",     ITimplements,    xbit DamlSyntaxBit),
+         ( "for",            ITfor,           xbit DamlSyntaxBit),
          ( "requires",       ITrequires,      xbit DamlSyntaxBit),
          ( "viewtype",       ITviewtype,      xbit DamlSyntaxBit)
      ]

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1222,11 +1222,8 @@ let_bindings_decl :: { Located ([AddAnn], LHsLocalBinds GhcPs) }
                                              , snd $ unLoc $2) }
 
 interface_instance :: { Located ParsedInterfaceInstance }
-  : 'interface' 'instance' qtycon 'for' qtycon where_impl
+  : 'interface' 'instance' qtycon 'for' qtycon where_inst
       { sL (comb3 $1 $5 $6) $ ParsedInterfaceInstance $3 $5 $6 }
-
-where_impl :: { Located [LHsDecl GhcPs] }
-  : where_inst { fmap (fromOL . snd) $1 }
 
 choice_group_decl :: { Located (LHsExpr GhcPs , Located [Located ChoiceData]) }
   : 'controller' party_list 'can' choice_decl_list

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -524,7 +524,7 @@ are the most common patterns, rewritten as regular expressions for clarity:
  'try'          { L _ ITtry }
  'catch'        { L _ ITcatch }
  'interface'    { L _ ITinterface }
- 'implements'   { L _ ITimplements }
+ 'for'          { L _ ITfor }
  'requires'     { L _ ITrequires }
  'viewtype'     { L _ ITviewtype }
 
@@ -1215,17 +1215,18 @@ template_body_decl :: { Located TemplateBodyDecl }
   | flex_choice_decl                             { sL1 $1 $ FlexChoiceDecl $1 }
   | key_decl                                     { sL1 $1 $ KeyDecl $1 }
   | maintainer_decl                              { sL1 $1 $ MaintainerDecl $1 }
-  | implements_group_decl                        { sL1 $1 $ ImplementsDecl $1 }
+  | interface_instance                           { sL1 $1 $ TemplateInterfaceInstanceDecl $1 }
 
 let_bindings_decl :: { Located ([AddAnn], LHsLocalBinds GhcPs) }
   : 'let' binds                 { sLL $1 $> (mj AnnWhere $1 : (fst $ unLoc $2)
                                              , snd $ unLoc $2) }
 
-implements_group_decl :: { Located ParsedImplementsDeclBlock }
-  : 'implements' qtycon where_impl { sLL $1 $2 $ ParsedImplementsDeclBlock $2 $3 }
+interface_instance :: { Located ParsedInterfaceInstance }
+  : 'interface' 'instance' qtycon 'for' qtycon where_impl
+      { sL (comb3 $1 $5 $6) $ ParsedInterfaceInstance $3 $5 $6 }
 
-where_impl :: { [LHsDecl GhcPs] }
-  : where_inst { fromOL (snd (unLoc $1)) }
+where_impl :: { Located [LHsDecl GhcPs] }
+  : where_inst { fmap (fromOL . snd) $1 }
 
 choice_group_decl :: { Located (LHsExpr GhcPs , Located [Located ChoiceData]) }
   : 'controller' party_list 'can' choice_decl_list
@@ -3852,6 +3853,7 @@ varid :: { Located RdrName }
         | 'key'            { sL1 $1 $! mkUnqual varName (fsLit "key") }
         | 'maintainer'     { sL1 $1 $! mkUnqual varName (fsLit "maintainer") }
         | 'message'        { sL1 $1 $! mkUnqual varName (fsLit "message") }
+        | 'for'            { sL1 $1 $! mkUnqual varName (fsLit "for") }
         -- If this changes relative to tyvarid, update 'checkRuleTyVarBndrNames' in RdrHsSyn.hs
         -- See Note [Parsing explicit foralls in Rules]
 

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1379,7 +1379,10 @@ interface_body_decl
         { sL (comb3 $2 $6 $>) $ InterfaceChoiceDecl (InterfaceChoiceSignature Nothing $2 $4 $6 $5) (unLoc $7) }
   | consuming_ 'choice' tycon OF_TYPE btype_ maybe_docprev arecord_with_opt interface_choice_body
         { sL (comb3 $3 $7 $>) $ InterfaceChoiceDecl (InterfaceChoiceSignature (Just (unLoc $1)) $3 $5 $7 $6) (unLoc $8) }
-  | var OF_TYPE sigtype maybe_docprev { sL1 $1 $ InterfaceFunctionSignatureDecl $1 $3 $4 }
+  | var OF_TYPE sigtype maybe_docprev
+        { sL1 $1 $ InterfaceFunctionSignatureDecl $1 $3 $4 }
+  | interface_instance
+        { sL1 $1 $ InterfaceInterfaceInstanceDecl $1 }
 
 interface_view_type_decl :: { Located InterfaceBodyDecl }
 interface_view_type_decl

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2390,16 +2390,16 @@ instance Monoid TemplateBodyDecls where
 
 templateBodyDeclToDecls :: Located TemplateBodyDecl -> TemplateBodyDecls
 templateBodyDeclToDecls (L _ decl) = case decl of
-  EnsureDecl e                 -> TemplateBodyDecls [e] [] [] [] [] [] [] [] [] []
-  SignatoryDecl s              -> TemplateBodyDecls [] [s] [] [] [] [] [] [] [] []
-  ObserverDecl o               -> TemplateBodyDecls [] [] [o] [] [] [] [] [] [] []
-  AgreementDecl a              -> TemplateBodyDecls [] [] [] [a] [] [] [] [] [] []
-  ChoiceGroupDecl g            -> TemplateBodyDecls [] [] [] [] [g] [] [] [] [] []
-  LetBindingsDecl (L _ (_, b)) -> TemplateBodyDecls [] [] [] [] [] [b] [] [] [] []
-  FlexChoiceDecl f             -> TemplateBodyDecls [] [] [] [] [] [] [f] [] [] []
-  KeyDecl k                    -> TemplateBodyDecls [] [] [] [] [] [] [] [k] [] []
-  MaintainerDecl m             -> TemplateBodyDecls [] [] [] [] [] [] [] [] [m] []
-  TemplateInterfaceInstanceDecl d -> TemplateBodyDecls [] [] [] [] [] [] [] [] [] [d]
+  EnsureDecl e -> mempty { tbdEnsures = [e] }
+  SignatoryDecl s -> mempty { tbdSignatories = [s] }
+  ObserverDecl o -> mempty { tbdObservers = [o] }
+  AgreementDecl a -> mempty { tbdAgreements = [a] }
+  ChoiceGroupDecl g -> mempty { tbdControlledChoiceGroups = [g] }
+  LetBindingsDecl (L _ (_, b)) -> mempty { tbdLetBindings = [b] }
+  FlexChoiceDecl f -> mempty { tbdFlexChoices = [f] }
+  KeyDecl k -> mempty { tbdKeys = [k] }
+  MaintainerDecl m -> mempty { tbdMaintainers = [m] }
+  TemplateInterfaceInstanceDecl d -> mempty { tbdInterfaceInstances = [d] }
 
 -- | Classify a list of template body declarations.
 extractTemplateBodyDecls :: [Located TemplateBodyDecl] -> TemplateBodyDecls

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -414,10 +414,7 @@ mkRoleAnnotDecl loc tycon roles
 
 --  | Groups together bindings for a single function
 cvTopDecls :: OrdList (LHsDecl GhcPs) -> [LHsDecl GhcPs]
-cvTopDecls decls = groupValDecls (fromOL decls)
-
-groupValDecls :: [LHsDecl GhcPs] -> [LHsDecl GhcPs]
-groupValDecls = go
+cvTopDecls decls = go (fromOL decls)
   where
     go :: [LHsDecl GhcPs] -> [LHsDecl GhcPs]
     go []                     = []
@@ -2322,7 +2319,7 @@ data InterfaceChoiceBody = InterfaceChoiceBody
 data ParsedInterfaceInstance = ParsedInterfaceInstance
   { piiInterface :: Located RdrName
   , piiTemplate :: Located RdrName
-  , piiDefs :: Located [LHsDecl GhcPs]
+  , piiDefs :: Located ([AddAnn], OrdList (LHsDecl GhcPs))
   }
 
 -- | Any declaration that can appear within a template
@@ -3207,7 +3204,7 @@ validateInterfaceInstance ::
   -> P (Located ValidInterfaceInstance)
 validateInterfaceInstance parent (L loc piib) = do
   checkParent
-  impls <- mapM validateMethodImpl (groupValDecls (unLoc piiDefs))
+  impls <- mapM validateMethodImpl (cvTopDecls $ snd $ unLoc piiDefs)
   checkMultipleDecls impls
   mapM_ checkNumArgs impls
 

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3924,6 +3924,11 @@ mkInterfaceDecl tycon (L requiresLoc requires) decls = do
       | (methodName, methodType, mbDocString) <- viFunctionSignatures
       ]
 
+    interfaceInterfaceInstances <- concat <$>
+      traverse
+        (mkInterfaceInstanceDecls viInterfaceName (noLoc emptyLocalBinds))
+        viInterfaceInstances
+
     pure $ toOL
       $ existential
       : hasInterfaceTypeRepInstance
@@ -3937,6 +3942,7 @@ mkInterfaceDecl tycon (L requiresLoc requires) decls = do
       ++ choiceTys
       ++ choiceDecls
       ++ viewTypeDecls
+      ++ interfaceInterfaceInstances
   where
     classVar = noLoc $ Unqual (mkTyVarOcc "t")
     classTy = noLoc $ HsTyVar noExt NotPromoted classVar

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2889,8 +2889,8 @@ allLetBindings includeBindings args vtLetBindings =
 
 -- | Construct instances for split-up Template typeclass, i.e., instances for all the single-method typeclasses
 -- that constitute the Template constraint synonym.
-mkTemplateInstanceDecl :: LHsLocalBinds GhcPs -> Located String -> Located RdrName -> ValidTemplate -> [LHsDecl GhcPs]
-mkTemplateInstanceDecl sharedBinds templateName conName ValidTemplate{..} =
+mkTemplateInstances :: LHsLocalBinds GhcPs -> Located String -> Located RdrName -> ValidTemplate -> [LHsDecl GhcPs]
+mkTemplateInstances sharedBinds templateName conName ValidTemplate{..} =
   [ signatoryInstance
   , observerInstance
   , ensureInstance
@@ -2968,8 +2968,8 @@ mkHasInterfaceViewDecl iface (Just viewType) = pure $
         `mkAppTy` viewType)
       (unitBag (mkPrimMethod "_view" "EViewInterface"))
 
-mkInterfaceInstanceDecl :: LHsType GhcPs -> [LHsDecl GhcPs]
-mkInterfaceInstanceDecl interfaceType =
+mkInterfaceInstances :: LHsType GhcPs -> [LHsDecl GhcPs]
+mkInterfaceInstances interfaceType =
   [ mkInstance "HasToAnyTemplate" $ mkPrimMethod "_toAnyTemplate" "EToAnyTemplate"
   , mkInstance "HasFromAnyTemplate" $ mkPrimMethod "_fromAnyTemplate" "EFromAnyTemplate"
   , mkInstance "HasTemplateTypeRep" $ mkPrimMethod "_templateTypeRep" "ETemplateTypeRep"
@@ -3450,7 +3450,7 @@ mkTemplateDecls templateName fields decls = do
       templateDataDecl = mkTemplateDataDecl (combineLocs vtTemplateName fields) vtTemplateName ci
       (letDecls,sharedBinds) = shareTemplateLetBindings conName vtLetBindings
       choicesWithArchive = mkArchiveChoice : vtChoices
-      templateInstances = mkTemplateInstanceDecl sharedBinds templateName conName vt
+      templateInstances = mkTemplateInstances sharedBinds templateName conName vt
       choiceInstanceDecls = concatMap (mkChoiceInstanceDecl templateName) choicesWithArchive
       choiceByKeyInstanceDecls = concatMap (mkChoiceByKeyInstanceDecl templateName vt) choicesWithArchive
       choiceDecls = concatMap (mkChoiceDecls (getLoc templateName) conName sharedBinds) choicesWithArchive
@@ -3779,8 +3779,7 @@ mkInterfaceDecl tycon (L requiresLoc requires) decls = do
           ]
 
         ifaceInstances :: [LHsDecl GhcPs]
-        ifaceInstances =
-          mkInterfaceInstanceDecl ifaceTy
+        ifaceInstances = mkInterfaceInstances ifaceTy
 
         choiceInstances :: [LHsDecl GhcPs]
         choiceInstances = concat $

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -146,7 +146,6 @@ import Control.Monad
 import Text.ParserCombinators.ReadP as ReadP
 import Data.Char
 import Data.Function (on)
-import Data.List (groupBy, sortOn)
 import qualified Data.Monoid as Monoid
 import Data.Data       ( dataTypeOf, fromConstr, dataTypeConstrs )
 import Bag

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2238,12 +2238,14 @@ data InterfaceBodyDecl
   = InterfaceFunctionSignatureDecl (Located RdrName) (LHsType GhcPs) (Maybe LHsDocString)
   | InterfaceChoiceDecl InterfaceChoiceSignature InterfaceChoiceBody
   | InterfaceViewDecl (LHsType GhcPs)
+  | InterfaceInterfaceInstanceDecl (Located ParsedInterfaceInstance)
 
 data InterfaceBodyDecls = InterfaceBodyDecls
   { ibdFunctionSignatures :: [(Located RdrName, LHsType GhcPs, Maybe LHsDocString)]
   , ibdChoices :: [(InterfaceChoiceSignature, InterfaceChoiceBody)]
   , ibdEnsures :: [LHsExpr GhcPs]
   , ibdViewDecls :: [LHsType GhcPs]
+  , ibdInterfaceInstances :: [Located ParsedInterfaceInstance]
   }
 
 instance Semigroup InterfaceBodyDecls where
@@ -2252,16 +2254,18 @@ instance Semigroup InterfaceBodyDecls where
     , ibdChoices = ibdChoices a Monoid.<> ibdChoices b
     , ibdEnsures = ibdEnsures a Monoid.<> ibdEnsures b
     , ibdViewDecls = ibdViewDecls a Monoid.<> ibdViewDecls b
+    , ibdInterfaceInstances = ibdInterfaceInstances a Monoid.<> ibdInterfaceInstances b
     }
 
 instance Monoid InterfaceBodyDecls where
-  mempty = InterfaceBodyDecls [] [] [] []
+  mempty = InterfaceBodyDecls [] [] [] [] []
 
 interfaceBodyDeclToDecls :: InterfaceBodyDecl -> InterfaceBodyDecls
 interfaceBodyDeclToDecls = \case
   InterfaceFunctionSignatureDecl name ty mbDocString -> mempty { ibdFunctionSignatures = [(name, ty, mbDocString)] }
   InterfaceChoiceDecl signature body                 -> mempty { ibdChoices = [(signature, body)] }
   InterfaceViewDecl viewType                         -> mempty { ibdViewDecls = [viewType] }
+  InterfaceInterfaceInstanceDecl interfaceInstance   -> mempty { ibdInterfaceInstances = [interfaceInstance] }
 
 extractInterfaceBodyDecls :: [Located InterfaceBodyDecl] -> InterfaceBodyDecls
 extractInterfaceBodyDecls = foldMap (interfaceBodyDeclToDecls . unLoc)

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3495,6 +3495,7 @@ mkInterfaceImplements templateName conName sharedBinds (L loc implements) = do
       { viiInterface = implementsInterface
       , viiTemplate = _unused
       , viiDefs = implementsDefs
+      , viiView
       } = implements
     templateInterfaceName =
       intercalate "_" $ mangle <$>
@@ -3526,8 +3527,7 @@ mkInterfaceImplements templateName conName sharedBinds (L loc implements) = do
 
     implementsView :: [LHsDecl GhcPs]
     implementsView =
-      let ValidInterfaceInstance _ _ _ view = implements
-          L loc (ValidInterfaceInstanceMethodDecl _ viimdMatches) = view
+      let L loc (ValidInterfaceInstanceMethodDecl _ viimdMatches) = viiView
 
           fullViewName =
             noLoc $ mkRdrUnqual $ mkVarOcc $


### PR DESCRIPTION
Daml PR: https://github.com/digital-asset/daml/pull/14715


Part of https://github.com/digital-asset/daml/issues/14047