### PR TITLE
Distinguish guarded exercises from unguarded exercises

### DIFF
--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3044,7 +3044,7 @@ mkInterfaceFixedChoiceInstanceDecl tycon InterfaceChoiceSignature {..} =
         Nothing)
   , mkInstance "HasExercise"
       exerciseContext
-      (mkTemplateClassMethod "exercise" [pred, cid, arg]
+      (mkTemplateClassMethod "exercise" [cid, arg]
         (mkPrimitive "primitive" "UExerciseInterface"
           `mkApp` (mkParExpr $ mkQualVar (mkVarOcc "toInterfaceContractId")
                     `mkAppType` ifaceType

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3027,7 +3027,7 @@ mkInterfaceFixedChoiceInstanceDecl tycon InterfaceChoiceSignature {..} =
   , mkInstance "HasExerciseGuarded"
       exerciseContext
       (mkTemplateClassMethod "exerciseGuarded" [pred, cid, arg]
-        (mkPrimitive "primitive" "UExerciseInterface"
+        (mkPrimitive "primitive" "UExerciseInterfaceGuarded"
           `mkApp` (mkParExpr $ mkQualVar (mkVarOcc "toInterfaceContractId")
                     `mkAppType` ifaceType
                     `mkApp` mkUnqualVar (mkVarOcc "cid"))
@@ -3039,8 +3039,12 @@ mkInterfaceFixedChoiceInstanceDecl tycon InterfaceChoiceSignature {..} =
         Nothing)
   , mkInstance "HasExercise"
       exerciseContext
-      (mkTemplateClassMethod "exercise" []
-        (mkQualVar (mkVarOcc "_exerciseDefault"))
+      (mkTemplateClassMethod "exercise" [pred, cid, arg]
+        (mkPrimitive "primitive" "UExerciseInterface"
+          `mkApp` (mkParExpr $ mkQualVar (mkVarOcc "toInterfaceContractId")
+                    `mkAppType` ifaceType
+                    `mkApp` mkUnqualVar (mkVarOcc "cid"))
+          `mkApp` (mkUnqualVar (mkVarOcc "arg")))
         Nothing)
   ]
   where


### PR DESCRIPTION
Generate different LFConversion primitives depending on whether an exercise is guarded or not

Daml PR: https://github.com/digital-asset/daml/pull/14773