### PR TITLE
Fix return type error for methods

### DIFF
--- a/compiler/typecheck/TcDaml.hs
+++ b/compiler/typecheck/TcDaml.hs
@@ -212,8 +212,8 @@ pprq :: Outputable a => a -> SDoc
 pprq = quotes . ppr
 
 isTemplate, isInterface :: DamlInfo -> Name -> Bool
-isTemplate info name = name `elem` templates info
-isInterface info name = name `elem` interfaces info
+isTemplate info name = name `S.member` templates info
+isInterface info name = name `S.member` interfaces info
 
 variantName :: DamlInfo -> Name -> SDoc
 variantName info name

--- a/compiler/typecheck/TcDaml.hs
+++ b/compiler/typecheck/TcDaml.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns #-}
 module TcDaml where
 
@@ -101,11 +102,14 @@ customDamlError ct
   | TyConApp con [TyConApp target [], TyConApp choice [], result] <- ctev_pred (ctEvidence ct)
   , check ["DA.Internal.Desugar", "DA.Internal.Template.Functions"] "HasExercise" con
   = Just $ TriedExercise { target = tyConName target, choice = tyConName choice, result }
-  | TyConApp con [TyConApp target [], LitTy (StrTyLit methodName), result] <- ctev_pred (ctEvidence ct)
+  | TyConApp con (_ `Snoc` TyConApp target [] `Snoc` LitTy (StrTyLit methodName) `Snoc` result) <- ctev_pred (ctEvidence ct)
   , check ["DA.Internal.Desugar"] "HasMethod" con
   = Just $ TriedImplementMethod { target = tyConName target, method = methodName, result }
   | otherwise
   = Nothing
+
+pattern Snoc xs x <- ((\xs -> (init xs, last xs)) -> (xs, x)) where
+  Snoc xs x = xs ++ [x]
 
 printListWithHeader :: SDoc -> SDoc -> [SDoc] -> SDoc
 printListWithHeader emptyMsg _ [] = emptyMsg

--- a/compiler/typecheck/TcDaml.hs
+++ b/compiler/typecheck/TcDaml.hs
@@ -55,7 +55,7 @@ customDamlErrors ct = do
   pure $ do
     e <- customDamlError ct
     m <- displayError info e
-    pure (vcat [m, ppr info])
+    pure m
 
 data DamlError
   = TriedView { target :: Name, result :: Type }

--- a/compiler/typecheck/TcDaml.hs
+++ b/compiler/typecheck/TcDaml.hs
@@ -108,7 +108,10 @@ customDamlError ct
   | otherwise
   = Nothing
 
-pattern Snoc xs x <- ((\xs -> (init xs, last xs)) -> (xs, x)) where
+snoc :: [a] -> Maybe ([a], a)
+snoc [] = Nothing
+snoc xs = Just (init xs, last xs)
+pattern Snoc xs x <- (snoc -> Just (xs, x)) where
   Snoc xs x = xs ++ [x]
 
 printListWithHeader :: SDoc -> SDoc -> [SDoc] -> SDoc

--- a/compiler/typecheck/TcErrors.hs
+++ b/compiler/typecheck/TcErrors.hs
@@ -527,7 +527,7 @@ reportWanteds ctxt tc_lvl (WC { wc_simple = simples, wc_impl = implics })
        ; traceTc "rw2" (ppr tidy_cts)
 
          -- First deal with daml errors
-       ; envDamlInfo <- getEnvDaml
+       ; _ <- getEnvDaml -- populate global DamlInfo, also committing it to the trace
        ; let ctxt_for_insols = ctxt { cec_suppress = False }
        ; (post_daml_ctxt, cts0) <- tryReporters ctxt_for_insols report0 tidy_cts
 

--- a/compiler/typecheck/TcErrors.hs
+++ b/compiler/typecheck/TcErrors.hs
@@ -527,6 +527,7 @@ reportWanteds ctxt tc_lvl (WC { wc_simple = simples, wc_impl = implics })
        ; traceTc "rw2" (ppr tidy_cts)
 
          -- First deal with daml errors
+       ; envDamlInfo <- getEnvDaml
        ; let ctxt_for_insols = ctxt { cec_suppress = False }
        ; (post_daml_ctxt, cts0) <- tryReporters ctxt_for_insols report0 tidy_cts
 

--- a/compiler/typecheck/TcRnTypes.hs
+++ b/compiler/typecheck/TcRnTypes.hs
@@ -301,12 +301,12 @@ instance ContainsModule gbl => ContainsModule (Env gbl lcl) where
     extractModule env = extractModule (env_gbl env)
 
 data DamlInfo = DamlInfo
-  { templates :: [Name]
-  , interfaces :: [Name]
-  , choices :: [(Name, Name, Type)]
+  { templates :: Set Name
+  , interfaces :: Set Name
+  , choices :: Map Name (Name, Type)
   , methods :: [(FastString, (Name, Type))]
   , implementations :: [(Name, Name)]
-  , views :: [(Name, Type)]
+  , views :: Map Name Type
   }
 
 {-

--- a/compiler/typecheck/TcRnTypes.hs
+++ b/compiler/typecheck/TcRnTypes.hs
@@ -29,6 +29,7 @@ module TcRnTypes(
         IfGblEnv(..), IfLclEnv(..),
         tcVisibleOrphanMods,
         DamlInfo(..),
+        DamlSynonym(..),
 
         -- Frontend types (shouldn't really be here)
         FrontendResult(..),
@@ -300,6 +301,11 @@ instance ContainsDynFlags (Env gbl lcl) where
 instance ContainsModule gbl => ContainsModule (Env gbl lcl) where
     extractModule env = extractModule (env_gbl env)
 
+data DamlSynonym = TemplateSyn | InterfaceSyn | ChoiceSyn
+  deriving (Show, Eq, Ord)
+
+instance Outputable DamlSynonym where ppr = text . show
+
 data DamlInfo = DamlInfo
   { templates :: Set Name
   , interfaces :: Set Name
@@ -307,6 +313,7 @@ data DamlInfo = DamlInfo
   , methods :: [(FastString, (Name, Type))]
   , implementations :: [(Name, Name)]
   , views :: Map Name Type
+  , synonyms :: Map Name (Name, DamlSynonym)
   }
 
 {-


### PR DESCRIPTION
Tackling issue: https://github.com/digital-asset/daml/issues/15890
Corresponding DAML changes: https://github.com/digital-asset/daml/pull/15999

- Separates missing methods from mistyped methods in the custom error checker.
- Resolves type synonyms inside of our custom error detector before checking for mismatches.
- Replaces fields in DamlInfo with equivalents with better runtime constants