### PR TITLE
Switch list pretty printing to use ::

### DIFF
--- a/compiler/deSugar/PmExpr.hs
+++ b/compiler/deSugar/PmExpr.hs
@@ -435,7 +435,7 @@ pprPmExprCon (RealDataCon con) args
     pretty_list :: PmPprM SDoc
     pretty_list = case isNilPmExpr (last list) of
       True  -> brackets . fsep . punctuate comma <$> mapM pprPmExpr (init list)
-      False -> parens   . hcat . punctuate dcolon <$> mapM pprPmExpr list
+      False -> parens   . hcat . punctuate list_cons <$> mapM pprPmExpr list
 
     list = list_elements args
 

--- a/compiler/deSugar/PmExpr.hs
+++ b/compiler/deSugar/PmExpr.hs
@@ -435,7 +435,7 @@ pprPmExprCon (RealDataCon con) args
     pretty_list :: PmPprM SDoc
     pretty_list = case isNilPmExpr (last list) of
       True  -> brackets . fsep . punctuate comma <$> mapM pprPmExpr (init list)
-      False -> parens   . hcat . punctuate colon <$> mapM pprPmExpr list
+      False -> parens   . hcat . punctuate dcolon <$> mapM pprPmExpr list
 
     list = list_elements args
 

--- a/compiler/utils/Outputable.hs
+++ b/compiler/utils/Outputable.hs
@@ -25,7 +25,7 @@ module Outputable (
         int, intWithCommas, integer, word, float, double, rational, doublePrec,
         parens, cparen, brackets, braces, quotes, quote,
         doubleQuotes, angleBrackets,
-        semi, comma, colon, dcolon, of_type, space, equals, dot, vbar,
+        semi, comma, colon, dcolon, list_cons, of_type, space, equals, dot, vbar,
         arrow, larrow, darrow, arrowt, larrowt, arrowtt, larrowtt,
         lparen, rparen, lbrack, rbrack, lbrace, rbrace, underscore,
         blankLine, forAllLit, kindType, bullet,
@@ -613,7 +613,7 @@ quotes d =
              ('\'' : _, _)       -> pp_d
              _other              -> Pretty.quotes pp_d
 
-semi, comma, colon, equals, space, dcolon, of_type, underscore, dot, vbar :: SDoc
+semi, comma, colon, equals, space, dcolon, list_cons, of_type, underscore, dot, vbar :: SDoc
 arrow, larrow, darrow, arrowt, larrowt, arrowtt, larrowtt :: SDoc
 lparen, rparen, lbrack, rbrack, lbrace, rbrace, blankLine :: SDoc
 
@@ -645,6 +645,11 @@ of_type    =
                        if performNewColonConvention dflags
                        then colon
                        else dcolon
+list_cons  =
+  sdocWithDynFlags $ \dflags ->
+                       if performNewColonConvention dflags
+                       then dcolon
+                       else colon
 
 forAllLit :: SDoc
 forAllLit = unicodeSyntax (char '∀') (text "forall")


### PR DESCRIPTION
Relevant issue https://github.com/digital-asset/daml/issues/8947
- Switches list specific pretty printing logic to use `dcolon` over `colon`