### PR TITLE
Allow template argument shadowing in choices

### DIFF
--- a/DA/Internal/Desugar.hs
+++ b/DA/Internal/Desugar.hs
@@ -25,7 +25,7 @@ module DA.Internal.Desugar
 where
 
 import GHC.TypeLits (Symbol)
-import GHC.Types (primitive)
+import GHC.Types (primitive, magic)
 import Data.String (IsString(..))
 
 data Any
@@ -238,3 +238,6 @@ mkInterfaceView _ = InterfaceView ()
 class HasField (x : Symbol) r a | x r -> a where
     getField : r -> a
     setField : a -> r -> r
+
+bypassReduceLambda : forall a. a -> a
+bypassReduceLambda = magic @"bypassReduceLambda"

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2910,7 +2910,7 @@ mkChoiceDecls templateLoc conName binds (CombinedChoiceData controllers observer
         mkBodyBinds args = noLetBindingsIfArchive (extendLetBindings binds (dummyBinds args))
         mkBody args body = mkLambda args body $ mkBodyBinds args
         mkSplitBody args1 args2 body =
-          mkLambda args1 (mkLambda args2 body (mkBodyBinds $ args1 ++ args2)) Nothing
+          mkLambda args1 (mkApp (mkQualVar $ mkVarOcc "bypassReduceLambda") $ mkLambda args2 body (mkBodyBinds $ args1 ++ args2)) Nothing
 
 emptyString :: LHsExpr GhcPs
 emptyString = noLoc $ HsLit noExt $ HsString NoSourceText $ fsLit ""


### PR DESCRIPTION
Resolves https://github.com/digital-asset/daml/issues/2186
- Allows choice arguments to shadow template arguments by splitting up the lambda