### PR TITLE
Add `let _ = this` in exception messages

### DIFF
--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3544,17 +3544,16 @@ mkExceptionInstanceDecls ValidException{..} =
   where
     exceptionType = rdrNameToType veExnName
     this =
-      case veFields of
-        L _ (HsRecTy _ []) ->
-          asPatPrefixCon "this" veConName
-        _ ->
-          asPatRecWild "this" veConName
+      if isEmptyRecord veFields
+        then asPatPrefixCon "this" veConName
+        else asPatRecWild "this" veConName
+
     messageMethod =
       case veMessage of
         Nothing ->
           mkMethod "message" [] (mkUnqualVar (mkVarOcc "show"))
         Just messageBody ->
-          mkMethod "message" [this] messageBody
+          mkMethod "message" [this] $ noLoc $ HsLet noExt (mkLetBindings $ dummyBinds [this]) messageBody
 
     mkInstance name method = instDecl $
       classInstDecl (mkQualClass name `mkAppTy` exceptionType) (unitBag method)


### PR DESCRIPTION
Resolves https://github.com/digital-asset/daml/issues/11004
- Changes exception message instance method from `message this@E {..} = ...` to `message this@E {..} = let _ = this in ...` to avoid unused bind warning