### PR TITLE
Generate HasSoft{Fetch,Exercise} instances

### DIFF
--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3011,6 +3011,7 @@ mkTemplateInstances sharedBinds templateName conName ValidTemplate{..} =
   , archiveInstance
   , mkInstance "HasCreate" $ mkPrimMethod "create" "UCreate"
   , mkInstance "HasFetch" $ mkPrimMethod "fetch" "UFetch"
+  , mkInstance "HasSoftFetch" $ mkPrimMethod "_softFetch" "USoftFetch"
   , mkInstance "HasToAnyTemplate" $ mkPrimMethod "_toAnyTemplate" "EToAnyTemplate"
   , mkInstance "HasFromAnyTemplate" $ mkPrimMethod "_fromAnyTemplate" "EFromAnyTemplate"
   , mkInstance "HasTemplateTypeRep" $ mkPrimMethod "_templateTypeRep" "ETemplateTypeRep"
@@ -3111,6 +3112,8 @@ mkChoiceInstanceDecl :: Located String -> CombinedChoiceData -> [LHsDecl GhcPs]
 mkChoiceInstanceDecl templateName CombinedChoiceData { ccdChoiceData = ChoiceData{..} } =
   [ mkInstance "HasExercise" [templateType, choiceType, returnType]
       (mkPrimMethod "exercise" "UExercise")
+  , mkInstance "HasSoftExercise" [templateType, choiceType, returnType]
+      (mkPrimMethod "_softExercise" "UExercise")
   , mkInstance "HasToAnyChoice" [templateType, choiceType, returnType]
       (mkPrimMethod "_toAnyChoice" "EToAnyChoice")
   , mkInstance "HasFromAnyChoice" [templateType, choiceType, returnType]


### PR DESCRIPTION
DA-GHC PR: https://github.com/digital-asset/ghc/pull/167
Daml PR: https://github.com/digital-asset/daml/pull/16938

---

This takes care of the GHC side of support for the new functions `softFetch` and `softExercise`.

Note: keeping as draft until we merge https://github.com/digital-asset/daml/pull/16893, which defines the `HasSoftExercise` class.