### PR TITLE
Drop reversing logic from controllers

### DIFF
--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -51,7 +51,7 @@ import PackageConfig
 import OrdList
 import BooleanFormula   ( BooleanFormula(..), LBooleanFormula(..), mkTrue )
 import FastString
-import Maybes           ( isJust, orElse )
+import Maybes           ( fromMaybe, isJust, listToMaybe, orElse )
 import Outputable
 
 -- compiler/basicTypes
@@ -1355,10 +1355,11 @@ maintainer_decl :: { LHsExpr GhcPs }
 
 party_list :: { Located [LHsExpr GhcPs] }
   : '{' parties '}'                              { sLL $1 $> (unLoc $2) }
-  | vocurly parties close                        { let ps = reverse (unLoc $2) in
-                                                    L (comb2 $1
-                                                        (last (void $1:map void ps))
+  | vocurly parties close                        { let ps = unLoc $2 in
+                                                    L (getLoc $ fromMaybe (void $1) $
+                                                        listToMaybe (map void ps)
                                                       ) $ ps }
+
 parties :: { Located [LHsExpr GhcPs] }
   : parties ',' exp                              { sLL $1 $> $ applyToParties $3 : (unLoc $1) }
   | parties ','                                  { sLL $1 $> $ unLoc $1 }

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1361,8 +1361,11 @@ party_list :: { Located [LHsExpr GhcPs] }
                                                       ) $ ps }
 
 parties :: { Located [LHsExpr GhcPs] }
-  : parties ',' exp                              { sLL $1 $> $ applyToParties $3 : (unLoc $1) }
-  | parties ','                                  { sLL $1 $> $ unLoc $1 }
+  : parties_rev                                  { fmap reverse $1 }
+
+parties_rev :: { Located [LHsExpr GhcPs] }
+  : parties_rev ',' exp                          { sLL $1 $> $ applyToParties $3 : (unLoc $1) }
+  | parties_rev ','                              { sLL $1 $> $ unLoc $1 }
   | exp                                          { sL1 $1 [applyToParties $1] }
 
 btype_ :: { LHsType GhcPs } -- Like 'btype' but excludes @arecord_with@


### PR DESCRIPTION
This drops the reversing logic from the one path in `party_list` to match the other, and to match `parties`

TODO: consider the consequences of making party_list always reverse (to be correct), and only using party_list over parties. As party_list simply requires the virtual curlys, and it's non-obvious why the other constructs in the language do not