### PR TITLE
Remove support for `controller..can` syntax

### DIFF
--- a/compiler/main/DynFlags.hs
+++ b/compiler/main/DynFlags.hs
@@ -837,7 +837,6 @@ data WarningFlag =
    | Opt_WarnImplicitKindVars             -- Since 8.6
    | Opt_WarnSpaceAfterBang
    | Opt_WarnMissingDerivingStrategies    -- Since 8.8
-   | Opt_WarnControllerCan
    | Opt_WarnUnsupportedDamlFieldNames
    | Opt_WarnTemplateLet
    deriving (Eq, Show, Enum)
@@ -4054,7 +4053,6 @@ wWarningFlagsDeps = [
   flagSpec "star-binder"                 Opt_WarnStarBinder,
   flagSpec "star-is-type"                Opt_WarnStarIsType,
   flagSpec "missing-space-after-bang"    Opt_WarnSpaceAfterBang,
-  flagSpec "controller-can"              Opt_WarnControllerCan,
   flagSpec "unsupported-daml-field-names"
                                          Opt_WarnUnsupportedDamlFieldNames,
   flagSpec "template-let"                Opt_WarnTemplateLet,
@@ -4772,7 +4770,6 @@ standardWarnings -- see Note [Documenting warning flags]
         Opt_WarnStarBinder,
         Opt_WarnInaccessibleCode,
         Opt_WarnSpaceAfterBang,
-        Opt_WarnControllerCan,
         Opt_WarnUnsupportedDamlFieldNames,
         Opt_WarnTemplateLet
       ]

--- a/compiler/parser/Lexer.x
+++ b/compiler/parser/Lexer.x
@@ -640,7 +640,6 @@ data Token
 
   | ITdaml
   | ITtemplate
-  | ITcan
   | ITensure
   | ITsignatory
   | ITagreement
@@ -889,7 +888,6 @@ reservedWordsFM = listToUFM $
 
          ( "daml",           ITdaml,          xbit DamlSyntaxBit),
          ( "template",       ITtemplate,      xbit DamlSyntaxBit),
-         ( "can",            ITcan,           xbit DamlSyntaxBit),
          ( "ensure",         ITensure,        xbit DamlSyntaxBit),
          ( "signatory",      ITsignatory,     xbit DamlSyntaxBit),
          ( "agreement",      ITagreement,     xbit DamlSyntaxBit),
@@ -1553,7 +1551,6 @@ maybe_layout t = do -- If the alternative layout rule is enabled then
           f ITwhere = pushLexState layout
           f ITwith  = pushLexState layout
           f ITcontroller = pushLexState layout
-          f ITcan   = pushLexState layout
           f ITrec   = pushLexState layout
           f ITif    = pushLexState layout_if
           f _       = return ()

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -4255,18 +4255,6 @@ warnSpaceAfterBang span = do
             text "If you mean to bind (!) then perhaps you want" $$
             text "to add a space after the bang for clarity."
 
--- | Warn about deprecated @controller ... can@ syntax
-warnControllerCan :: SrcSpan -> P ()
-warnControllerCan span = do
-    addWarning Opt_WarnControllerCan span msg
-    where
-      msg = text "The syntax 'controller ... can' is deprecated," $$
-            text "it will be removed in a future version of Daml." $$
-            text "Instead, use 'choice ... with ... controller' syntax." $$
-            text "Note that 'choice ... with ... controller' syntax does not " $$
-            text "implicitly add the controller as an observer," $$
-            text "so it must be added explicitly as one (or as a signatory)."
-
 -- | Warn about deprecated @template .. let@ syntax
 warnTemplateLet :: SrcSpan -> P ()
 warnTemplateLet span = do

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -1211,7 +1211,7 @@ template_body_decl :: { Located TemplateBodyDecl }
   | observer_decl                                { sL1 $1 $ ObserverDecl $1 }
   | agreement_decl                               { sL1 $1 $ AgreementDecl $1 }
   | let_bindings_decl                            { sL1 $1 $ LetBindingsDecl $1 }
-  | flex_choice_decl                             { sL1 $1 $ FlexChoiceDecl $1 }
+  | template_choice_decl                         { sL1 $1 $ TemplateChoiceDecl $1 }
   | key_decl                                     { sL1 $1 $ KeyDecl $1 }
   | maintainer_decl                              { sL1 $1 $ MaintainerDecl $1 }
   | interface_instance                           { sL1 $1 $ TemplateInterfaceInstanceDecl $1 }
@@ -1230,12 +1230,12 @@ interface_instance :: { Located ParsedInterfaceInstance }
   : 'interface' 'instance' qtycon 'for' qtycon where_inst
       { sL (comb3 $1 $5 $6) $ ParsedInterfaceInstance $3 $5 $6 }
 
-flex_choice_decl :: { Located FlexChoiceData }
+template_choice_decl :: { Located TemplateChoiceData }
   : consuming 'choice' qtycon OF_TYPE btype_ maybe_docprev arecord_with_opt choice_parties doexp
       -- NOTE: We use `btype_` (`btype` excluding record `with` types) to
       -- prevent the choice return type capturing the `with` parameter types.
     { sL (comb3 $1 $2 $>) $
-        FlexChoiceData $8
+        TemplateChoiceData $8
             ChoiceData { cdChoiceName = $3
                        , cdChoiceReturnTy = $5
                        , cdChoiceFields = $7

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -2409,7 +2409,6 @@ data TemplateBodyDecl
   | SignatoryDecl (LHsExpr GhcPs)
   | ObserverDecl (LHsExpr GhcPs)
   | AgreementDecl (LHsExpr GhcPs)
-  | ChoiceGroupDecl (Located (LHsExpr GhcPs, Located [Located ChoiceData]))
   | LetBindingsDecl (Located ([AddAnn], LHsLocalBinds GhcPs))
   | FlexChoiceDecl (Located FlexChoiceData)
   | KeyDecl (Located (LHsExpr GhcPs, LHsType GhcPs))
@@ -2422,7 +2421,6 @@ data TemplateBodyDecls = TemplateBodyDecls {
     , tbdSignatories :: [LHsExpr GhcPs]
     , tbdObservers :: [LHsExpr GhcPs]
     , tbdAgreements :: [LHsExpr GhcPs]
-    , tbdControlledChoiceGroups :: [Located (LHsExpr GhcPs, Located [Located ChoiceData])]
     , tbdLetBindings :: [LHsLocalBinds GhcPs]
     , tbdFlexChoices :: [Located FlexChoiceData]
     , tbdKeys :: [Located (LHsExpr GhcPs, LHsType GhcPs)]
@@ -2462,7 +2460,6 @@ instance Semigroup TemplateBodyDecls where
     , tbdSignatories = tbdSignatories x Monoid.<> tbdSignatories y
     , tbdObservers = tbdObservers x Monoid.<> tbdObservers y
     , tbdAgreements = tbdAgreements x Monoid.<> tbdAgreements y
-    , tbdControlledChoiceGroups = tbdControlledChoiceGroups x Monoid.<> tbdControlledChoiceGroups y
     , tbdLetBindings = tbdLetBindings x Monoid.<> tbdLetBindings y
     , tbdFlexChoices = tbdFlexChoices x Monoid.<> tbdFlexChoices y
     , tbdKeys = tbdKeys x Monoid.<> tbdKeys y
@@ -2471,7 +2468,7 @@ instance Semigroup TemplateBodyDecls where
     }
 
 instance Monoid TemplateBodyDecls where
-  mempty = TemplateBodyDecls [] [] [] [] [] [] [] [] [] []
+  mempty = TemplateBodyDecls [] [] [] [] [] [] [] [] []
 
 templateBodyDeclToDecls :: Located TemplateBodyDecl -> TemplateBodyDecls
 templateBodyDeclToDecls (L _ decl) = case decl of
@@ -2479,7 +2476,6 @@ templateBodyDeclToDecls (L _ decl) = case decl of
   SignatoryDecl s -> mempty { tbdSignatories = [s] }
   ObserverDecl o -> mempty { tbdObservers = [o] }
   AgreementDecl a -> mempty { tbdAgreements = [a] }
-  ChoiceGroupDecl g -> mempty { tbdControlledChoiceGroups = [g] }
   LetBindingsDecl (L _ (_, b)) -> mempty { tbdLetBindings = [b] }
   FlexChoiceDecl f -> mempty { tbdFlexChoices = [f] }
   KeyDecl k -> mempty { tbdKeys = [k] }
@@ -3262,7 +3258,7 @@ validateTemplate vtTemplateName tbd@TemplateBodyDecls{..}
         , vtChoices
         , vtEnsure = listToMaybe tbdEnsures
         , vtSignatories = applyConcat (noLoc tbdSignatories)
-        , vtObservers
+        , vtObservers = applyConcat (noLoc tbdObservers)
         , vtAgreement = listToMaybe tbdAgreements
         , vtLetBindings = fromMaybe (noLoc emptyLocalBinds) (listToMaybe tbdLetBindings)
         , vtKeyData
@@ -3277,44 +3273,12 @@ validateTemplate vtTemplateName tbd@TemplateBodyDecls{..}
     vtKeyData = (fmap . fmap) (\(kdKeyExpr, kdKeyType) -> KeyData{..}) (listToMaybe tbdKeys)
     kdMaintainers = applyConcat $ noLoc tbdMaintainers
 
-    -- | Full list of observers includes all controllers of controlled choice groups.
-    vtObservers = allTemplateObservers (mergeDecls tbdObservers) $ map (fst . unLoc) tbdControlledChoiceGroups
-
-    -- | Combine support multiple 'observer' and 'maintainer' declarations into
-    -- a single list expression.
-    mergeDecls :: [LHsExpr GhcPs] -> Maybe (LHsExpr GhcPs)
-    mergeDecls [] = Nothing
-    mergeDecls xs = Just $ applyConcat $ noLoc xs -- TODO(RJR): Combine locations from the list elements
-
-    -- | Calculate an expression for the full list of a contract's observers.
-    -- TODO(RJR): Figure out how to simplify this
-    allTemplateObservers
-      :: Maybe (LHsExpr GhcPs) -- ^ Explicit (list of) observers.
-      -> [LHsExpr GhcPs]       -- ^ Contract controllers (list of lists).
-      -> LHsExpr GhcPs         -- ^ Union (list) of observers and controllers.
-    allTemplateObservers obs controllers =
-      let app = applyConcat (L noSrcSpan $ maybeToList obs ++ controllers)
-      in case obs of
-           Nothing -> app
-           Just (L loc _) -> L loc (unLoc app)
-
 combineChoices :: TemplateBodyDecls -> P [CombinedChoiceData]
-combineChoices TemplateBodyDecls{..} = do
-  flexCcds <-
-    sequence [ flexChoiceToCombinedChoice TemplateChoice (unLoc fc)
-             | fc <- tbdFlexChoices
-             ]
-  pure $ (choiceGroupsToCombinedChoices tbdControlledChoiceGroups ++ flexCcds)
-
--- | Convert controlled choice groups to a list of individual choices with controllers.
--- Leave type variable information empty, to be added afterwards.
-choiceGroupsToCombinedChoices
-  :: [Located (LHsExpr GhcPs, Located [Located ChoiceData])]
-  -> [CombinedChoiceData]
-choiceGroupsToCombinedChoices = concatMap distributeController
-  where
-    distributeController (L _ (controller, L _ choices)) = map (makeCombinedChoice controller) choices
-    makeCombinedChoice controller choice = CombinedChoiceData controller Nothing Nothing (unLoc choice) False TemplateChoice
+combineChoices TemplateBodyDecls{..} =
+  sequence
+    [ flexChoiceToCombinedChoice TemplateChoice (unLoc fc)
+    | fc <- tbdFlexChoices
+    ]
 
 data TemplateOrInterface a b
   = TorI_Template a


### PR DESCRIPTION
Part of https://github.com/digital-asset/daml/issues/17361

Daml PR: https://github.com/digital-asset/daml/pull/17362
DA-GHC PR: https://github.com/digital-asset/ghc/pull/171
docs.daml.com PR: https://github.com/digital-asset/docs.daml.com/pull/453