### PR TITLE
Add warning categories (backport)

### DIFF
--- a/compiler/basicTypes/BasicTypes.hs
+++ b/compiler/basicTypes/BasicTypes.hs
@@ -32,6 +32,7 @@ module BasicTypes(
         FunctionOrData(..),
 
         WarningTxt(..), pprWarningTxtForMsg, StringLiteral(..),
+        WarningCategory (..), mkWarningCategory, defaultWarningCategory, validWarningCategory, warningTxtCategory,
 
         Fixity(..), FixityDirection(..),
         defaultFixity, maxPrecedence, minPrecedence,
@@ -113,9 +114,11 @@ import GhcPrelude
 
 import FastString
 import Outputable
-import SrcLoc ( Located,unLoc )
+import SrcLoc ( Located, GenLocated(..), unLoc )
+import Data.Char (isAlphaNum)
 import Data.Data hiding (Fixity, Prefix, Infix)
 import Data.Function (on)
+import Data.List (isPrefixOf)
 
 {-
 ************************************************************************
@@ -328,6 +331,78 @@ initialVersion = 1
 ************************************************************************
 -}
 
+{-
+Note [Warning categories]
+~~~~~~~~~~~~~~~~~~~~~~~~~
+See GHC Proposal 541 for the design of the warning categories feature:
+https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0541-warning-pragmas-with-categories.rst
+
+A WARNING pragma may be annotated with a category such as "x-partial" written
+after the 'in' keyword, like this:
+
+    {-# WARNING in "x-partial" head "This function is partial..." #-}
+
+This is represented by the 'Maybe (Located WarningCategory)' field in
+'WarningTxt'.  The parser will accept an arbitrary string as the category name,
+then the renamer (in 'rnWarningTxt') will check it contains only valid
+characters, so we can generate a nicer error message than a parse error.
+
+The corresponding warnings can then be controlled with the -Wx-partial,
+-Wno-x-partial, -Werror=x-partial and -Wwarn=x-partial flags.  Such a flag is
+distinguished from an 'unrecognisedWarning' by the flag parser testing
+'validWarningCategory'.  The 'x-' prefix means we can still usually report an
+unrecognised warning where the user has made a mistake.
+
+A DEPRECATED pragma may not have a user-defined category, and is always treated
+as belonging to the special category 'deprecations'.  Similarly, a WARNING
+pragma without a category belongs to the 'deprecations' category.
+Thus the '-Wdeprecations' flag will enable all of the following:
+
+    {-# WARNING in "deprecations" foo "This function is deprecated..." #-}
+    {-# WARNING foo "This function is deprecated..." #-}
+    {-# DEPRECATED foo "This function is deprecated..." #-}
+
+The '-Wwarnings-deprecations' flag is supported for backwards compatibility
+purposes as being equivalent to '-Wdeprecations'.
+
+The '-Wextended-warnings' warning group collects together all warnings with
+user-defined categories, so they can be enabled or disabled
+collectively. Moreover they are treated as being part of other warning groups
+such as '-Wdefault' (see 'warningGroupIncludesExtendedWarnings').
+
+'DynFlags' and 'DiagOpts' each contain a set of enabled and a set of fatal
+warning categories, just as they do for the finite enumeration of 'WarningFlag's
+built in to GHC.  These are represented as 'WarningCategorySet's to allow for
+the possibility of them being infinite.
+
+-}
+
+-- See Note [Warning categories]
+newtype WarningCategory = WarningCategory FastString
+  deriving (Data, Eq, Show)
+
+instance Outputable WarningCategory where
+  ppr (WarningCategory catName) = ftext catName
+
+mkWarningCategory :: FastString -> WarningCategory
+mkWarningCategory = WarningCategory
+
+-- | The @deprecations@ category is used for all DEPRECATED pragmas and for
+-- WARNING pragmas that do not specify a category.
+defaultWarningCategory :: WarningCategory
+defaultWarningCategory = mkWarningCategory (mkFastString "deprecations")
+
+-- | Is this warning category allowed to appear in user-defined WARNING pragmas?
+-- It must either be the known category @deprecations@, or be a custom category
+-- that begins with @x-@ and contains only valid characters (letters, numbers,
+-- apostrophes and dashes).
+validWarningCategory :: WarningCategory -> Bool
+validWarningCategory cat@(WarningCategory c) =
+    cat == defaultWarningCategory || ("x-" `isPrefixOf` s && all is_allowed s)
+  where
+    s = unpackFS c
+    is_allowed c = isAlphaNum c || c == '\'' || c == '-'
+
 -- | A String Literal in the source, including its original raw format for use by
 -- source to source manipulation tools.
 data StringLiteral = StringLiteral
@@ -345,19 +420,28 @@ instance Outputable StringLiteral where
 -- | Warning Text
 --
 -- reason/explanation from a WARNING or DEPRECATED pragma
-data WarningTxt = WarningTxt (Located SourceText)
+data WarningTxt = WarningTxt (Maybe (Located WarningCategory))
+                             (Located SourceText)
                              [Located StringLiteral]
-                | DeprecatedTxt (Located SourceText)
+                | DeprecatedTxt (Maybe (Located WarningCategory))
+                                (Located SourceText)
                                 [Located StringLiteral]
     deriving (Eq, Data)
 
+-- | To which warning category does this WARNING or DEPRECATED pragma belong?
+-- See Note [Warning categories].
+warningTxtCategory :: WarningTxt -> WarningCategory
+warningTxtCategory (WarningTxt (Just (L _ cat)) _ _) = cat
+warningTxtCategory (DeprecatedTxt (Just (L _ cat)) _ _) = cat
+warningTxtCategory _ = defaultWarningCategory
+
 instance Outputable WarningTxt where
-    ppr (WarningTxt    lsrc ws)
+    ppr (WarningTxt _ lsrc ws)
       = case unLoc lsrc of
           NoSourceText   -> pp_ws ws
           SourceText src -> text src <+> pp_ws ws <+> text "#-}"
 
-    ppr (DeprecatedTxt lsrc  ds)
+    ppr (DeprecatedTxt _ lsrc ds)
       = case unLoc lsrc of
           NoSourceText   -> pp_ws ds
           SourceText src -> text src <+> pp_ws ds <+> text "#-}"
@@ -371,9 +455,9 @@ pp_ws ws
 
 
 pprWarningTxtForMsg :: WarningTxt -> SDoc
-pprWarningTxtForMsg (WarningTxt    _ ws)
+pprWarningTxtForMsg (WarningTxt _ _ ws)
                      = doubleQuotes (vcat (map (ftext . sl_fs . unLoc) ws))
-pprWarningTxtForMsg (DeprecatedTxt _ ds)
+pprWarningTxtForMsg (DeprecatedTxt _ _ ds)
                      = text "Deprecated:" <+>
                        doubleQuotes (vcat (map (ftext . sl_fs . unLoc) ds))
 

--- a/compiler/basicTypes/BasicTypes.hs
+++ b/compiler/basicTypes/BasicTypes.hs
@@ -337,7 +337,7 @@ Note [Warning categories]
 See GHC Proposal 541 for the design of the warning categories feature:
 https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0541-warning-pragmas-with-categories.rst
 
-A WARNING pragma may be annotated with a category such as "x-partial" written
+A WARNING/DEPRECATED pragma may be annotated with a category such as "x-partial" written
 after the 'in' keyword, like this:
 
     {-# WARNING in "x-partial" head "This function is partial..." #-}
@@ -353,22 +353,13 @@ distinguished from an 'unrecognisedWarning' by the flag parser testing
 'validWarningCategory'.  The 'x-' prefix means we can still usually report an
 unrecognised warning where the user has made a mistake.
 
-A DEPRECATED pragma may not have a user-defined category, and is always treated
-as belonging to the special category 'deprecations'.  Similarly, a WARNING
-pragma without a category belongs to the 'deprecations' category.
-Thus the '-Wdeprecations' flag will enable all of the following:
-
     {-# WARNING in "deprecations" foo "This function is deprecated..." #-}
     {-# WARNING foo "This function is deprecated..." #-}
+    {-# DEPRECATED in "deprecations" foo "This function is deprecated..." #-}
     {-# DEPRECATED foo "This function is deprecated..." #-}
 
 The '-Wwarnings-deprecations' flag is supported for backwards compatibility
 purposes as being equivalent to '-Wdeprecations'.
-
-The '-Wextended-warnings' warning group collects together all warnings with
-user-defined categories, so they can be enabled or disabled
-collectively. Moreover they are treated as being part of other warning groups
-such as '-Wdefault' (see 'warningGroupIncludesExtendedWarnings').
 
 'DynFlags' and 'DiagOpts' each contain a set of enabled and a set of fatal
 warning categories, just as they do for the finite enumeration of 'WarningFlag's

--- a/compiler/hsSyn/HsDecls.hs
+++ b/compiler/hsSyn/HsDecls.hs
@@ -2304,8 +2304,14 @@ instance (p ~ GhcPass pass,OutputableBndr (IdP p))
 instance (p ~ GhcPass pass, OutputableBndr (IdP p))
        => Outputable (WarnDecl p) where
     ppr (Warning _ thing txt)
-      = hsep ( punctuate comma (map ppr thing))
+      = ppr_category
+              <+> hsep (punctuate comma (map ppr thing))
               <+> ppr txt
+      where
+        ppr_category = case txt of
+                         WarningTxt (Just cat) _ _ -> text "[" <> ppr (unLoc cat) <> text "]"
+                         DeprecatedTxt (Just cat) _ _ -> text "[" <> ppr (unLoc cat) <> text "]"
+                         _ -> empty
     ppr (XWarnDecl x) = ppr x
 
 {-

--- a/compiler/main/DynFlags.hs
+++ b/compiler/main/DynFlags.hs
@@ -26,6 +26,7 @@ module DynFlags (
         PlatformConstants(..),
         FatalMessager, LogAction, FlushOut(..), FlushErr(..),
         ProfAuto(..),
+        warnReasonFromWarningTxt,
         glasgowExtsFlags,
         warningGroups, warningHierarchies,
         hasPprDebug, hasNoDebugOutput, hasNoStateHack, hasNoOptCoercion,
@@ -34,6 +35,10 @@ module DynFlags (
         gopt, gopt_set, gopt_unset, setGeneralFlag', unSetGeneralFlag',
         wopt, wopt_set, wopt_unset,
         wopt_fatal, wopt_set_fatal, wopt_unset_fatal,
+        wopt_custom, wopt_fatal_custom,
+        wopt_set_all_custom, wopt_unset_all_custom, wopt_set_all_fatal_custom, wopt_unset_all_fatal_custom,
+        wopt_set_custom, wopt_unset_custom, wopt_set_fatal_custom, wopt_unset_fatal_custom, wopt_any_custom,
+
         xopt, xopt_set, xopt_unset,
         xopt_set_unlessExplSpec,
         lang_set,
@@ -205,10 +210,14 @@ import Maybes
 import MonadUtils
 import qualified Pretty
 import SrcLoc
-import BasicTypes       ( IntWithInf, treatZeroAsInf )
+import BasicTypes       ( IntWithInf, WarningCategory(..), WarningTxt(..)
+                        , defaultWarningCategory, mkWarningCategory, treatZeroAsInf
+                        , validWarningCategory, warningTxtCategory )
 import FastString
 import Fingerprint
 import Outputable
+import Unique
+import UniqSet
 import Foreign.C        ( CInt(..) )
 import System.IO.Unsafe ( unsafeDupablePerformIO )
 import {-# SOURCE #-} ErrUtils ( Severity(..), MsgDoc, mkLocMessageAnn
@@ -723,7 +732,58 @@ data WarnReason
   | Reason !WarningFlag
   -- | Warning was made an error because of -Werror or -Werror=WarningFlag
   | ErrReason !(Maybe WarningFlag)
+  -- | Warning was enabled due to its category
+  | CategoryReason !WarningCategory
   deriving Show
+
+-- | Build WarnReason from WarningTxt
+warnReasonFromWarningTxt :: WarningTxt -> WarnReason
+warnReasonFromWarningTxt = CategoryReason . warningTxtCategory
+
+instance Uniquable WarningCategory where
+  getUnique (WarningCategory catName) = getUnique catName
+
+-- | A finite or infinite set of warning categories.
+--
+-- Unlike 'WarningFlag', there are (in principle) infinitely many warning
+-- categories, so we cannot necessarily enumerate all of them. However the set
+-- is constructed by adding or removing categories one at a time, so we can
+-- represent it as either a finite set of categories, or a cofinite set (where
+-- we store the complement).
+data WarningCategorySet =
+    FiniteWarningCategorySet   (UniqSet WarningCategory)
+      -- ^ The set of warning categories is the given finite set.
+  | CofiniteWarningCategorySet (UniqSet WarningCategory)
+      -- ^ The set of warning categories is infinite, so the constructor stores
+      -- its (finite) complement.
+
+-- | The empty set of warning categories.
+emptyWarningCategorySet :: WarningCategorySet
+emptyWarningCategorySet = FiniteWarningCategorySet emptyUniqSet
+
+-- | The set consisting of all possible warning categories.
+completeWarningCategorySet :: WarningCategorySet
+completeWarningCategorySet = CofiniteWarningCategorySet emptyUniqSet
+
+-- | Is this set empty?
+nullWarningCategorySet :: WarningCategorySet -> Bool
+nullWarningCategorySet (FiniteWarningCategorySet s) = isEmptyUniqSet s
+nullWarningCategorySet CofiniteWarningCategorySet{} = False
+
+-- | Does this warning category belong to the set?
+elemWarningCategorySet :: WarningCategory -> WarningCategorySet -> Bool
+elemWarningCategorySet c (FiniteWarningCategorySet   s) =      c `elementOfUniqSet` s
+elemWarningCategorySet c (CofiniteWarningCategorySet s) = not (c `elementOfUniqSet` s)
+
+-- | Insert an element into a warning category set.
+insertWarningCategorySet :: WarningCategory -> WarningCategorySet -> WarningCategorySet
+insertWarningCategorySet c (FiniteWarningCategorySet   s) = FiniteWarningCategorySet   (addOneToUniqSet   s c)
+insertWarningCategorySet c (CofiniteWarningCategorySet s) = CofiniteWarningCategorySet (delOneFromUniqSet s c)
+
+-- | Delete an element from a warning category set.
+deleteWarningCategorySet :: WarningCategory -> WarningCategorySet -> WarningCategorySet
+deleteWarningCategorySet c (FiniteWarningCategorySet   s) = FiniteWarningCategorySet   (delOneFromUniqSet s c)
+deleteWarningCategorySet c (CofiniteWarningCategorySet s) = CofiniteWarningCategorySet (addOneToUniqSet   s c)
 
 -- | Used to differentiate the scope an include needs to apply to.
 -- We have to split the include paths to avoid accidentally forcing recursive
@@ -760,6 +820,7 @@ instance ToJson WarnReason where
   json (Reason wf) = JSString (show wf)
   json (ErrReason Nothing) = JSString "Opt_WarnIsError"
   json (ErrReason (Just wf)) = JSString (show wf)
+  json (CategoryReason cat) = JSString (show cat)
 
 data WarningFlag =
 -- See Note [Updating flag description in the User's Guide]
@@ -789,7 +850,6 @@ data WarningFlag =
    | Opt_WarnUnusedMatches
    | Opt_WarnUnusedTypePatterns
    | Opt_WarnUnusedForalls
-   | Opt_WarnWarningsDeprecations
    | Opt_WarnDeprecatedFlags
    | Opt_WarnMissingMonadFailInstances -- since 8.0
    | Opt_WarnSemigroup -- since 8.0
@@ -1062,6 +1122,8 @@ data DynFlags = DynFlags {
   generalFlags          :: EnumSet GeneralFlag,
   warningFlags          :: EnumSet WarningFlag,
   fatalWarningFlags     :: EnumSet WarningFlag,
+  customWarningCategories      :: WarningCategorySet, -- See Note [Warning categories]
+  fatalCustomWarningCategories :: WarningCategorySet, -- in GHC.Unit.Module.Warnings
   -- Don't change this without updating extensionFlags:
   language              :: Maybe Language,
   -- | Safe Haskell mode
@@ -1994,6 +2056,8 @@ defaultDynFlags mySettings (myLlvmTargets, myLlvmPasses) =
         generalFlags = EnumSet.fromList (defaultFlags mySettings),
         warningFlags = EnumSet.fromList standardWarnings,
         fatalWarningFlags = EnumSet.empty,
+        customWarningCategories = completeWarningCategorySet,
+        fatalCustomWarningCategories = emptyWarningCategorySet,
         ghciScripts = [],
         language = Nothing,
         safeHaskell = Sf_None,
@@ -2169,20 +2233,20 @@ defaultLogAction dflags reason severity srcSpan style msg
           NoReason -> Nothing
           Reason wflag -> do
             spec <- flagSpecOf wflag
-            return ("-W" ++ flagSpecName spec ++ warnFlagGrp wflag)
+            return ("-W" ++ flagSpecName spec ++ warnFlagGrp (smallestGroups wflag))
           ErrReason Nothing ->
             return "-Werror"
           ErrReason (Just wflag) -> do
             spec <- flagSpecOf wflag
             return $
-              "-W" ++ flagSpecName spec ++ warnFlagGrp wflag ++
+              "-W" ++ flagSpecName spec ++ warnFlagGrp (smallestGroups wflag) ++
               ", -Werror=" ++ flagSpecName spec
+          CategoryReason cat -> do
+            return ("-W" ++ show cat ++ warnFlagGrp smallestWarningGroupsForCategory)
 
-      warnFlagGrp flag
-          | gopt Opt_ShowWarnGroups dflags =
-                case smallestGroups flag of
-                    [] -> ""
-                    groups -> " (in " ++ intercalate ", " (map ("-W"++) groups) ++ ")"
+      warnFlagGrp groups
+          | gopt Opt_ShowWarnGroups dflags, not (null groups)
+                = "(in " ++ intercalate ", " (map ("-W"++) groups) ++ ")"
           | otherwise = ""
 
 -- | Like 'defaultLogActionHPutStrDoc' but appends an extra newline.
@@ -2358,6 +2422,12 @@ wopt_unset dfs f = dfs{ warningFlags = EnumSet.delete f (warningFlags dfs) }
 wopt_fatal :: WarningFlag -> DynFlags -> Bool
 wopt_fatal f dflags = f `EnumSet.member` fatalWarningFlags dflags
 
+wopt_custom :: WarningCategory -> DynFlags -> Bool
+wopt_custom wflag opts = wflag `elemWarningCategorySet` customWarningCategories opts
+
+wopt_fatal_custom :: WarningCategory -> DynFlags -> Bool
+wopt_fatal_custom wflag opts = wflag `elemWarningCategorySet` fatalCustomWarningCategories opts
+
 -- | Mark a 'WarningFlag' as fatal (do not set the flag)
 wopt_set_fatal :: DynFlags -> WarningFlag -> DynFlags
 wopt_set_fatal dfs f
@@ -2367,6 +2437,48 @@ wopt_set_fatal dfs f
 wopt_unset_fatal :: DynFlags -> WarningFlag -> DynFlags
 wopt_unset_fatal dfs f
     = dfs { fatalWarningFlags = EnumSet.delete f (fatalWarningFlags dfs) }
+
+-- | Enable all custom warning categories.
+wopt_set_all_custom :: DynFlags -> DynFlags
+wopt_set_all_custom dfs
+    = dfs{ customWarningCategories = completeWarningCategorySet }
+
+-- | Disable all custom warning categories.
+wopt_unset_all_custom :: DynFlags -> DynFlags
+wopt_unset_all_custom dfs
+    = dfs{ customWarningCategories = emptyWarningCategorySet }
+
+-- | Mark all custom warning categories as fatal (do not set the flags).
+wopt_set_all_fatal_custom :: DynFlags -> DynFlags
+wopt_set_all_fatal_custom dfs
+    = dfs { fatalCustomWarningCategories = completeWarningCategorySet }
+
+-- | Mark all custom warning categories as non-fatal.
+wopt_unset_all_fatal_custom :: DynFlags -> DynFlags
+wopt_unset_all_fatal_custom dfs
+    = dfs { fatalCustomWarningCategories = emptyWarningCategorySet }
+
+-- | Set a custom 'WarningCategory'
+wopt_set_custom :: DynFlags -> WarningCategory -> DynFlags
+wopt_set_custom dfs f = dfs{ customWarningCategories = insertWarningCategorySet f (customWarningCategories dfs) }
+
+-- | Unset a custom 'WarningCategory'
+wopt_unset_custom :: DynFlags -> WarningCategory -> DynFlags
+wopt_unset_custom dfs f = dfs{ customWarningCategories = deleteWarningCategorySet f (customWarningCategories dfs) }
+
+-- | Mark a custom 'WarningCategory' as fatal (do not set the flag)
+wopt_set_fatal_custom :: DynFlags -> WarningCategory -> DynFlags
+wopt_set_fatal_custom dfs f
+    = dfs { fatalCustomWarningCategories = insertWarningCategorySet f (fatalCustomWarningCategories dfs) }
+
+-- | Mark a custom 'WarningCategory' as not fatal
+wopt_unset_fatal_custom :: DynFlags -> WarningCategory -> DynFlags
+wopt_unset_fatal_custom dfs f
+    = dfs { fatalCustomWarningCategories = deleteWarningCategorySet f (fatalCustomWarningCategories dfs) }
+
+-- | Are there any custom warning categories enabled?
+wopt_any_custom :: DynFlags -> Bool
+wopt_any_custom dfs = not (nullWarningCategorySet (customWarningCategories dfs))
 
 -- | Test whether a 'LangExt.Extension' is set
 xopt :: LangExt.Extension -> DynFlags -> Bool
@@ -3718,20 +3830,19 @@ dynamic_flags_deps = [
  ++ map (mkFlag turnOff "dno-"      unSetGeneralFlag  ) dFlagsDeps
  ++ map (mkFlag turnOn  "f"         setGeneralFlag    ) fFlagsDeps
  ++ map (mkFlag turnOff "fno-"      unSetGeneralFlag  ) fFlagsDeps
- ++ map (mkFlag turnOn  "W"         setWarningFlag    ) wWarningFlagsDeps
- ++ map (mkFlag turnOff "Wno-"      unSetWarningFlag  ) wWarningFlagsDeps
- ++ map (mkFlag turnOn  "Werror="   setWErrorFlag )     wWarningFlagsDeps
- ++ map (mkFlag turnOn  "Wwarn="     unSetFatalWarningFlag )
-                                                        wWarningFlagsDeps
- ++ map (mkFlag turnOn  "Wno-error=" unSetFatalWarningFlag )
-                                                        wWarningFlagsDeps
- ++ map (mkFlag turnOn  "fwarn-"    setWarningFlag   . hideFlag)
-    wWarningFlagsDeps
- ++ map (mkFlag turnOff "fno-warn-" unSetWarningFlag . hideFlag)
-    wWarningFlagsDeps
- ++ [ (NotDeprecated, unrecognisedWarning "W"),
-      (Deprecated,    unrecognisedWarning "fwarn-"),
-      (Deprecated,    unrecognisedWarning "fno-warn-") ]
+ ++ warningControls setWarningFlag unSetWarningFlag setWErrorFlag unSetFatalWarningFlag wWarningFlagsDeps
+ ++ warningControls setCustomWarningFlag unSetCustomWarningFlag setCustomWErrorFlag unSetCustomFatalWarningFlag
+      [ (NotDeprecated, FlagSpec "warnings-deprecations" defaultWarningCategory nop AllModes)
+      , (NotDeprecated, FlagSpec "deprecations" defaultWarningCategory nop AllModes)
+      ]
+ ++ [ (NotDeprecated, customOrUnrecognisedWarning "Wno-"       unSetCustomWarningFlag)
+    , (NotDeprecated, customOrUnrecognisedWarning "Werror="    setCustomWErrorFlag)
+    , (NotDeprecated, customOrUnrecognisedWarning "Wwarn="     unSetCustomFatalWarningFlag)
+    , (NotDeprecated, customOrUnrecognisedWarning "Wno-error=" unSetCustomFatalWarningFlag)
+    , (NotDeprecated, customOrUnrecognisedWarning "W"          setCustomWarningFlag)
+    , (Deprecated,    customOrUnrecognisedWarning "fwarn-"     setCustomWarningFlag)
+    , (Deprecated,    customOrUnrecognisedWarning "fno-warn-"  unSetCustomWarningFlag)
+    ]
  ++ [ make_ord_flag defFlag "Werror=compat"
         (NoArg (mapM_ setWErrorFlag minusWcompatOpts))
     , make_ord_flag defFlag "Wno-error=compat"
@@ -3753,13 +3864,39 @@ dynamic_flags_deps = [
                ("it does nothing; look into -XDefaultSignatures and " ++
                   "-XDeriveGeneric for generic programming support.") ]
 
--- | This is where we handle unrecognised warning flags. We only issue a warning
--- if -Wunrecognised-warning-flags is set. See Trac #11429 for context.
-unrecognisedWarning :: String -> Flag (CmdLineP DynFlags)
-unrecognisedWarning prefix = defHiddenFlag prefix (Prefix action)
+-- | Warnings have both new-style flags to control their state (@-W@, @-Wno-@,
+-- @-Werror=@, @-Wwarn=@) and old-style flags (@-fwarn-@, @-fno-warn-@).  We
+-- define these uniformly for individual warning flags and groups of warnings.
+warningControls :: (warn_flag -> DynP ()) -- ^ Set the warning
+                -> (warn_flag -> DynP ()) -- ^ Unset the warning
+                -> (warn_flag -> DynP ()) -- ^ Make the warning an error
+                -> (warn_flag -> DynP ()) -- ^ Clear the error status
+                -> [(Deprecation, FlagSpec warn_flag)]
+                -> [(Deprecation, Flag (CmdLineP DynFlags))]
+warningControls set unset set_werror unset_fatal xs =
+    map (mkFlag turnOn  "W"          set             ) xs
+ ++ map (mkFlag turnOff "Wno-"       unset           ) xs
+ ++ map (mkFlag turnOn  "Werror="    set_werror      ) xs
+ ++ map (mkFlag turnOn  "Wwarn="     unset_fatal     ) xs
+ ++ map (mkFlag turnOn  "Wno-error=" unset_fatal     ) xs
+ ++ map (mkFlag turnOn  "fwarn-"     set   . hideFlag) xs
+ ++ map (mkFlag turnOff "fno-warn-"  unset . hideFlag) xs
+
+-- | This is where we handle unrecognised warning flags. If the flag is valid as
+-- an extended warning category, we call the supplied action. Otherwise, issue a
+-- warning if -Wunrecognised-warning-flags is set. See #11429 for context.
+-- See Note [Warning categories] in GHC.Unit.Module.Warnings.
+customOrUnrecognisedWarning :: String -> (WarningCategory -> DynP ()) -> Flag (CmdLineP DynFlags)
+customOrUnrecognisedWarning prefix custom = defHiddenFlag prefix (Prefix action)
   where
     action :: String -> EwM (CmdLineP DynFlags) ()
-    action flag = do
+    action flag
+      | validWarningCategory cat = custom cat
+      | otherwise = unrecognised flag
+      where
+        cat = mkWarningCategory (mkFastString flag)
+
+    unrecognised flag = do
       f <- wopt Opt_WarnUnrecognisedWarningFlags <$> liftEwM getCmdLineState
       when f $ addFlagWarn Cmd.ReasonUnrecognisedFlag $
         "unrecognised warning flag: -" ++ prefix ++ flag
@@ -3970,7 +4107,6 @@ wWarningFlagsDeps = [
   flagSpec "deferred-type-errors"        Opt_WarnDeferredTypeErrors,
   flagSpec "deferred-out-of-scope-variables"
                                          Opt_WarnDeferredOutOfScopeVariables,
-  flagSpec "deprecations"                Opt_WarnWarningsDeprecations,
   flagSpec "deprecated-flags"            Opt_WarnDeprecatedFlags,
   flagSpec "deriving-typeable"           Opt_WarnDerivingTypeable,
   flagSpec "dodgy-exports"               Opt_WarnDodgyExports,
@@ -4041,7 +4177,6 @@ wWarningFlagsDeps = [
   flagSpec "unused-pattern-binds"        Opt_WarnUnusedPatternBinds,
   flagSpec "unused-top-binds"            Opt_WarnUnusedTopBinds,
   flagSpec "unused-type-patterns"        Opt_WarnUnusedTypePatterns,
-  flagSpec "warnings-deprecations"       Opt_WarnWarningsDeprecations,
   flagSpec "wrong-do-bind"               Opt_WarnWrongDoBind,
   flagSpec "missing-pattern-synonym-signatures"
                                     Opt_WarnMissingPatternSynonymSignatures,
@@ -4708,6 +4843,14 @@ warningGroups =
     , ("everything",   minusWeverythingOpts)
     ]
 
+warningGroupIncludesExtendedWarnings :: String -> Bool
+warningGroupIncludesExtendedWarnings "compat"            = False
+warningGroupIncludesExtendedWarnings "unused_binds"      = False
+warningGroupIncludesExtendedWarnings "default"           = True
+warningGroupIncludesExtendedWarnings "extra"             = True
+warningGroupIncludesExtendedWarnings "all"               = True
+warningGroupIncludesExtendedWarnings "everything"        = True
+
 -- | Warning group hierarchies, where there is an explicit inclusion
 -- relation.
 --
@@ -4739,11 +4882,16 @@ smallestGroups flag = mapMaybe go warningHierarchies where
         pure (Just group)
     go [] = Nothing
 
+-- | The smallest group in every hierarchy to which a custom warning
+-- category belongs is currently always @-Wdefault@.
+-- See Note [Warning categories] in "GHC.Unit.Module.Warnings".
+smallestWarningGroupsForCategory :: [String]
+smallestWarningGroupsForCategory = ["default"]
+
 -- | Warnings enabled unless specified otherwise
 standardWarnings :: [WarningFlag]
 standardWarnings -- see Note [Documenting warning flags]
     = [ Opt_WarnOverlappingPatterns,
-        Opt_WarnWarningsDeprecations,
         Opt_WarnDeprecatedFlags,
         Opt_WarnDeferredTypeErrors,
         Opt_WarnTypedHoles,
@@ -5016,6 +5164,7 @@ unSetGeneralFlag' f dflags = foldr ($) (gopt_unset dflags f) deps
    --     imply further flags.
 
 --------------------------
+
 setWarningFlag, unSetWarningFlag :: WarningFlag -> DynP ()
 setWarningFlag   f = upd (\dfs -> wopt_set dfs f)
 unSetWarningFlag f = upd (\dfs -> wopt_unset dfs f)
@@ -5028,6 +5177,27 @@ setWErrorFlag :: WarningFlag -> DynP ()
 setWErrorFlag flag =
   do { setWarningFlag flag
      ; setFatalWarningFlag flag }
+
+setCustomWarningFlag, unSetCustomWarningFlag :: WarningCategory -> DynP ()
+setCustomWarningFlag   f = upd (\dfs -> wopt_set_custom dfs f)
+unSetCustomWarningFlag f = upd (\dfs -> wopt_unset_custom dfs f)
+
+setCustomFatalWarningFlag, unSetCustomFatalWarningFlag :: WarningCategory -> DynP ()
+setCustomFatalWarningFlag   f = upd (\dfs -> wopt_set_fatal_custom dfs f)
+unSetCustomFatalWarningFlag f = upd (\dfs -> wopt_unset_fatal_custom dfs f)
+
+setCustomWErrorFlag :: WarningCategory -> DynP ()
+setCustomWErrorFlag flag =
+  do { setCustomWarningFlag flag
+     ; setCustomFatalWarningFlag flag }
+
+setCustomFlagsForGroup :: String -> DynP ()
+setCustomFlagsForGroup g | warningGroupIncludesExtendedWarnings g = upd wopt_set_all_custom
+setCustomFlagsForGroup _ = pure ()
+
+unsetCustomFlagsForGroup :: String -> DynP ()
+unsetCustomFlagsForGroup g | warningGroupIncludesExtendedWarnings g = upd wopt_unset_all_custom
+unsetCustomFlagsForGroup _ = pure ()
 
 --------------------------
 setExtensionFlag, unSetExtensionFlag :: LangExt.Extension -> DynP ()

--- a/compiler/main/DynFlags.hs
+++ b/compiler/main/DynFlags.hs
@@ -4855,6 +4855,7 @@ warningGroupIncludesExtendedWarnings "default"           = True
 warningGroupIncludesExtendedWarnings "extra"             = True
 warningGroupIncludesExtendedWarnings "all"               = True
 warningGroupIncludesExtendedWarnings "everything"        = True
+warningGroupIncludesExtendedWarnings _ = error "Tried to use non-existent group in warningGroupIncludesExtendedWarnings"
 
 -- | Warning group hierarchies, where there is an explicit inclusion
 -- relation.

--- a/compiler/main/DynFlags.hs
+++ b/compiler/main/DynFlags.hs
@@ -27,6 +27,7 @@ module DynFlags (
         FatalMessager, LogAction, FlushOut(..), FlushErr(..),
         ProfAuto(..),
         warnReasonFromWarningTxt,
+        getWarnReasonCategory,
         glasgowExtsFlags,
         warningGroups, warningHierarchies,
         hasPprDebug, hasNoDebugOutput, hasNoStateHack, hasNoOptCoercion,
@@ -739,6 +740,10 @@ data WarnReason
 -- | Build WarnReason from WarningTxt
 warnReasonFromWarningTxt :: WarningTxt -> WarnReason
 warnReasonFromWarningTxt = CategoryReason . warningTxtCategory
+
+getWarnReasonCategory :: WarnReason -> WarningCategory
+getWarnReasonCategory (CategoryReason cat) = cat
+getWarnReasonCategory _ = defaultWarningCategory
 
 instance Uniquable WarningCategory where
   getUnique (WarningCategory catName) = getUnique catName

--- a/compiler/main/ErrUtils.hs
+++ b/compiler/main/ErrUtils.hs
@@ -712,14 +712,18 @@ prettyPrintGhcErrors dflags
                           liftIO $ throwIO e
 
 -- | Checks if given 'WarnMsg' is a fatal warning.
-isWarnMsgFatal :: DynFlags -> WarnMsg -> Maybe (Maybe WarningFlag)
+isWarnMsgFatal :: DynFlags -> WarnMsg -> Maybe WarnReason
 isWarnMsgFatal dflags ErrMsg{errMsgReason = Reason wflag}
   = if wopt_fatal wflag dflags
-      then Just (Just wflag)
+      then Just $ ErrReason $ Just wflag
+      else Nothing
+isWarnMsgFatal dflags ErrMsg{errMsgReason = CategoryReason cat}
+  = if wopt_fatal_custom cat dflags
+      then Just $ CategoryReason cat
       else Nothing
 isWarnMsgFatal dflags _
   = if gopt Opt_WarnIsError dflags
-      then Just Nothing
+      then Just $ ErrReason Nothing
       else Nothing
 
 traceCmd :: DynFlags -> String -> String -> IO a -> IO a

--- a/compiler/main/HscTypes.hs
+++ b/compiler/main/HscTypes.hs
@@ -335,9 +335,9 @@ printOrThrowWarnings dflags warns = do
             case isWarnMsgFatal dflags warn of
               Nothing ->
                 (make_err, warn)
-              Just err_reason ->
+              Just warn_reason ->
                 (True, warn{ errMsgSeverity = SevError
-                           , errMsgReason = ErrReason err_reason
+                           , errMsgReason = warn_reason
                            }))
           False warns
   if make_error

--- a/compiler/parser/Parser.y
+++ b/compiler/parser/Parser.y
@@ -815,12 +815,12 @@ implicit_top :: { () }
         : {- empty -}                           {% pushModuleContext }
 
 maybemodwarning :: { Maybe (Located WarningTxt) }
-    : "{-# DEPRECATED" strings "#-}"
-                      {% ajs (Just (sLL $1 $> $ DeprecatedTxt (sL1 $1 (getDEPRECATED_PRAGs $1)) (snd $ unLoc $2)))
-                             (mo $1:mc $3: (fst $ unLoc $2)) }
-    | "{-# WARNING" strings "#-}"
-                         {% ajs (Just (sLL $1 $> $ WarningTxt (sL1 $1 (getWARNING_PRAGs $1)) (snd $ unLoc $2)))
-                                (mo $1:mc $3 : (fst $ unLoc $2)) }
+    : "{-# DEPRECATED" warning_category strings "#-}"
+                      {% ajs (Just (sLL $1 $> $ DeprecatedTxt $2 (sL1 $1 (getDEPRECATED_PRAGs $1)) (snd $ unLoc $3)))
+                             (mo $1:mc $4: (fst $ unLoc $3)) }
+    | "{-# WARNING" warning_category strings "#-}"
+                         {% ajs (Just (sLL $1 $> $ WarningTxt $2 (sL1 $1 (getWARNING_PRAGs $1)) (snd $ unLoc $3)))
+                                (mo $1:mc $4 : (fst $ unLoc $3)) }
     |  {- empty -}                  { Nothing }
 
 body    :: { ([AddAnn]
@@ -2011,6 +2011,10 @@ to varid (used for rule_vars), 'checkRuleTyVarBndrNames' must be updated.
 -----------------------------------------------------------------------------
 -- Warnings and deprecations (c.f. rules)
 
+warning_category :: { Maybe (Located WarningCategory) }
+        : 'in' STRING                  { Just (sL1 $2 (mkWarningCategory (getSTRING $2))) }
+        | {- empty -}                  { Nothing }
+
 warnings :: { OrdList (LWarnDecl GhcPs) }
         : warnings ';' warning         {% addAnnotation (oll $1) AnnSemi (gl $2)
                                           >> return ($1 `appOL` $3) }
@@ -2021,9 +2025,9 @@ warnings :: { OrdList (LWarnDecl GhcPs) }
 
 -- SUP: TEMPORARY HACK, not checking for `module Foo'
 warning :: { OrdList (LWarnDecl GhcPs) }
-        : namelist strings
-                {% amsu (sLL $1 $> (Warning noExt (unLoc $1) (WarningTxt (noLoc NoSourceText) $ snd $ unLoc $2)))
-                     (fst $ unLoc $2) }
+        : warning_category namelist strings
+                {% amsu (sLL $2 $> (Warning noExt (unLoc $2) (WarningTxt $1 (noLoc NoSourceText) $ snd $ unLoc $3)))
+                     (fst $ unLoc $3) }
 
 deprecations :: { OrdList (LWarnDecl GhcPs) }
         : deprecations ';' deprecation
@@ -2036,9 +2040,9 @@ deprecations :: { OrdList (LWarnDecl GhcPs) }
 
 -- SUP: TEMPORARY HACK, not checking for `module Foo'
 deprecation :: { OrdList (LWarnDecl GhcPs) }
-        : namelist strings
-             {% amsu (sLL $1 $> $ (Warning noExt (unLoc $1) (DeprecatedTxt (noLoc NoSourceText) $ snd $ unLoc $2)))
-                     (fst $ unLoc $2) }
+        : warning_category namelist strings
+             {% amsu (sLL $2 $> $ (Warning noExt (unLoc $2) (DeprecatedTxt $1 (noLoc NoSourceText) $ snd $ unLoc $3)))
+                     (fst $ unLoc $3) }
 
 strings :: { Located ([AddAnn],[Located StringLiteral]) }
     : STRING { sL1 $1 ([],[cL (gl $1) (getStringLiteral $1)]) }

--- a/compiler/rename/RnEnv.hs
+++ b/compiler/rename/RnEnv.hs
@@ -1236,12 +1236,12 @@ warnIfDeprecated gre@(GRE { gre_name = name, gre_imp = iss })
   | (imp_spec : _) <- iss
   = do { dflags <- getDynFlags
        ; this_mod <- getModule
-       ; when (wopt Opt_WarnWarningsDeprecations dflags &&
+       ; when (wopt_any_custom dflags &&
                not (nameIsLocalOrFrom this_mod name)) $
                    -- See Note [Handling of deprecations]
          do { iface <- loadInterfaceForName doc name
             ; case lookupImpDeprec iface gre of
-                Just txt -> addWarn (Reason Opt_WarnWarningsDeprecations)
+                Just txt -> addWarn (warnReasonFromWarningTxt txt)
                                    (mk_msg imp_spec txt)
                 Nothing  -> return () } }
   | otherwise

--- a/compiler/rename/RnNames.hs
+++ b/compiler/rename/RnNames.hs
@@ -369,9 +369,9 @@ rnImportDecl this_mod
         imports = calculateAvails dflags iface mod_safe' want_boot (ImportedByUser imv)
 
     -- Complain if we import a deprecated module
-    whenWOptM Opt_WarnWarningsDeprecations (
+    when (wopt_any_custom dflags) (
        case (mi_warns iface) of
-          WarnAll txt -> addWarn (Reason Opt_WarnWarningsDeprecations)
+          WarnAll txt -> addWarn (warnReasonFromWarningTxt txt)
                                 (moduleWarn imp_mod_name txt)
           _           -> return ()
      )
@@ -1739,10 +1739,10 @@ missingImportListItem ie
   = text "The import item" <+> quotes (ppr ie) <+> ptext (sLit "does not have an explicit import list")
 
 moduleWarn :: ModuleName -> WarningTxt -> SDoc
-moduleWarn mod (WarningTxt _ txt)
+moduleWarn mod (WarningTxt _ _ txt)
   = sep [ text "Module" <+> quotes (ppr mod) <> ptext (sLit ":"),
           nest 2 (vcat (map (ppr . sl_fs . unLoc) txt)) ]
-moduleWarn mod (DeprecatedTxt _ txt)
+moduleWarn mod (DeprecatedTxt _ _ txt)
   = sep [ text "Module" <+> quotes (ppr mod)
                                 <+> text "is deprecated:",
           nest 2 (vcat (map (ppr . sl_fs . unLoc) txt)) ]

--- a/compiler/rename/RnSource.hs
+++ b/compiler/rename/RnSource.hs
@@ -52,7 +52,7 @@ import NameEnv
 import Avail
 import Outputable
 import Bag
-import BasicTypes       ( pprRuleName )
+import BasicTypes       ( WarningTxt(..), WarningCategory(..), pprRuleName, validWarningCategory )
 import FastString
 import SrcLoc
 import DynFlags
@@ -296,6 +296,7 @@ rnSrcWarnDecls bndr_set decls'
        -- ensures that the names are defined locally
      = do { names <- concatMapM (lookupLocalTcNames sig_ctxt what . unLoc)
                                 rdr_names
+          ; _ <- checkWarningTextCategory txt
           ; return [(rdrNameOcc rdr, txt) | (rdr, _) <- names] }
    rn_deprec (XWarnDecl _) = panic "rnSrcWarnDecls"
 
@@ -303,6 +304,20 @@ rnSrcWarnDecls bndr_set decls'
 
    warn_rdr_dups = findDupRdrNames
                    $ concatMap (\(dL->L _ (Warning _ ns _)) -> ns) decls
+
+checkWarningTextCategory :: WarningTxt -> RnM ()
+checkWarningTextCategory txt = do
+  forM_ (getWarningTxtCategory txt) $ \(L loc cat) ->
+    unless (validWarningCategory cat) $
+      addErrAt loc $
+        vcat [ text "Warning category" <+> quotes (ppr cat) <+> text "is not valid"
+             , text "(user-defined category names must begin with" <+> quotes (text "x-")
+             , text "and contain only letters, numbers, apostrophes and dashes)"
+             ]
+  where
+    getWarningTxtCategory :: WarningTxt -> Maybe (Located WarningCategory)
+    getWarningTxtCategory (WarningTxt mb_cat _ _) = mb_cat
+    getWarningTxtCategory (DeprecatedTxt mb_cat _ _) = mb_cat
 
 findDupRdrNames :: [Located RdrName] -> [NonEmpty (Located RdrName)]
 findDupRdrNames = findDupsEq (\ x -> \ y -> rdrNameOcc (unLoc x) == rdrNameOcc (unLoc y))

--- a/compiler/typecheck/TcRnExports.hs
+++ b/compiler/typecheck/TcRnExports.hs
@@ -165,7 +165,7 @@ tcRnExports explicit_mod exports
                               tcg_rdr_env = rdr_env,
                               tcg_imports = imports,
                               tcg_src     = hsc_src }
- = unsetWOptM Opt_WarnWarningsDeprecations $
+ = updTopFlags wopt_unset_all_custom $
        -- Do not report deprecations arising from the export
        -- list, to avoid bleating about re-exporting a deprecated
        -- thing (especially via 'module Foo' export item)

--- a/compiler/typecheck/TcRnMonad.hs
+++ b/compiler/typecheck/TcRnMonad.hs
@@ -20,7 +20,7 @@ module TcRnMonad(
   getTopEnv, updTopEnv, getGblEnv, updGblEnv,
   setGblEnv, getLclEnv, updLclEnv, setLclEnv,
   getEnvs, setEnvs,
-  xoptM, doptM, goptM, woptM,
+  xoptM, doptM, goptM, woptM, updTopFlags,
   setXOptM, unsetXOptM, unsetGOptM, unsetWOptM,
   whenDOptM, whenGOptM, whenWOptM,
   whenXOptM, unlessXOptM,
@@ -478,21 +478,20 @@ goptM flag = do { dflags <- getDynFlags; return (gopt flag dflags) }
 woptM :: WarningFlag -> TcRnIf gbl lcl Bool
 woptM flag = do { dflags <- getDynFlags; return (wopt flag dflags) }
 
+updTopFlags :: (DynFlags -> DynFlags) -> TcRnIf gbl lcl a -> TcRnIf gbl lcl a
+updTopFlags f = updTopEnv (\top -> top { hsc_dflags = f $ hsc_dflags top })
+
 setXOptM :: LangExt.Extension -> TcRnIf gbl lcl a -> TcRnIf gbl lcl a
-setXOptM flag =
-  updTopEnv (\top -> top { hsc_dflags = xopt_set (hsc_dflags top) flag})
+setXOptM flag = updTopFlags (flip xopt_set flag)
 
 unsetXOptM :: LangExt.Extension -> TcRnIf gbl lcl a -> TcRnIf gbl lcl a
-unsetXOptM flag =
-  updTopEnv (\top -> top { hsc_dflags = xopt_unset (hsc_dflags top) flag})
+unsetXOptM flag = updTopFlags (flip xopt_unset flag)
 
 unsetGOptM :: GeneralFlag -> TcRnIf gbl lcl a -> TcRnIf gbl lcl a
-unsetGOptM flag =
-  updTopEnv (\top -> top { hsc_dflags = gopt_unset (hsc_dflags top) flag})
+unsetGOptM flag = updTopFlags (flip gopt_unset flag)
 
 unsetWOptM :: WarningFlag -> TcRnIf gbl lcl a -> TcRnIf gbl lcl a
-unsetWOptM flag =
-  updTopEnv (\top -> top { hsc_dflags = wopt_unset (hsc_dflags top) flag})
+unsetWOptM flag = updTopFlags (flip wopt_unset flag)
 
 -- | Do it flag is true
 whenDOptM :: DumpFlag -> TcRnIf gbl lcl () -> TcRnIf gbl lcl ()
@@ -977,16 +976,21 @@ reportError err
          writeTcRef errs_var (warns, errs `snocBag` err) }
 
 reportWarning :: WarnReason -> ErrMsg -> TcRn ()
-reportWarning reason err
-  = do { let warn = makeIntoWarning reason err
-                    -- 'err' was built by mkLongErrMsg or something like that,
-                    -- so it's of error severity.  For a warning we downgrade
-                    -- its severity to SevWarning
+reportWarning reason err = do 
+  shouldReport <- shouldReportWarning reason
+  when shouldReport $ do
+    -- 'err' was built by mkLongErrMsg or something like that,
+    -- so it's of error severity.  For a warning we downgrade
+    -- its severity to SevWarning
+    let warn = makeIntoWarning reason err
+    traceTc "Adding warning:" (pprLocErrMsg warn)
+    errs_var <- getErrsVar
+    (warns, errs) <- readTcRef errs_var
+    writeTcRef errs_var (warns `snocBag` warn, errs)
 
-       ; traceTc "Adding warning:" (pprLocErrMsg warn)
-       ; errs_var <- getErrsVar
-       ; (warns, errs) <- readTcRef errs_var
-       ; writeTcRef errs_var (warns `snocBag` warn, errs) }
+shouldReportWarning :: WarnReason -> TcRn Bool
+shouldReportWarning (CategoryReason cat) = wopt_custom cat <$> getDynFlags
+shouldReportWarning _ = pure False
 
 try_m :: TcRn r -> TcRn (Either IOEnvFailure r)
 -- Does tryM, with a debug-trace on failure

--- a/compiler/typecheck/TcRnMonad.hs
+++ b/compiler/typecheck/TcRnMonad.hs
@@ -989,8 +989,7 @@ reportWarning reason err = do
     writeTcRef errs_var (warns `snocBag` warn, errs)
 
 shouldReportWarning :: WarnReason -> TcRn Bool
-shouldReportWarning (CategoryReason cat) = wopt_custom cat <$> getDynFlags
-shouldReportWarning _ = pure False
+shouldReportWarning warnReason = wopt_custom (getWarnReasonCategory warnReason) <$> getDynFlags
 
 try_m :: TcRn r -> TcRn (Either IOEnvFailure r)
 -- Does tryM, with a debug-trace on failure

--- a/compiler/utils/Binary.hs
+++ b/compiler/utils/Binary.hs
@@ -948,6 +948,10 @@ instance Binary FastString where
     case getUserData bh of
         UserData { ud_get_fs = get_fs } -> get_fs bh
 
+instance Binary WarningCategory where
+  put_ bh (WarningCategory fs) = put_ bh fs
+  get bh = WarningCategory <$> get bh
+
 -- Here to avoid loop
 instance Binary LeftOrRight where
    put_ bh CLeft  = putByte bh 0
@@ -1118,24 +1122,28 @@ instance Binary Fixity where
           return (Fixity src aa ab)
 
 instance Binary WarningTxt where
-    put_ bh (WarningTxt s w) = do
+    put_ bh (WarningTxt c s w) = do
             putByte bh 0
+            put_ bh c
             put_ bh s
             put_ bh w
-    put_ bh (DeprecatedTxt s d) = do
+    put_ bh (DeprecatedTxt c s d) = do
             putByte bh 1
+            put_ bh c
             put_ bh s
             put_ bh d
 
     get bh = do
             h <- getByte bh
             case h of
-              0 -> do s <- get bh
+              0 -> do c <- get bh
+                      s <- get bh
                       w <- get bh
-                      return (WarningTxt s w)
-              _ -> do s <- get bh
+                      return (WarningTxt c s w)
+              _ -> do c <- get bh
+                      s <- get bh
                       d <- get bh
-                      return (DeprecatedTxt s d)
+                      return (DeprecatedTxt c s d)
 
 instance Binary StringLiteral where
   put_ bh (StringLiteral st fs) = do


### PR DESCRIPTION
Backport of [this commit](https://github.com/ghc/ghc/commit/f932c5890ec358aa0cbba547eb6982168e13da37#diff-11a772bbf0ea00c1ef268401771311fc0fb88c63a601f08713ee8ca80724be77), extended to cover Deprecations as well as Warnings (original commit only allows categories on warnings)

Some changes needed as GHC structure has changed a fair bit, mostly structural
Did not port over the `--Wextended-warnings` flag from the above commit, as its not necessary for us.