### PR TITLE
Bump haddock to patched version that works with da-8.8.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -93,9 +93,9 @@
 	ignore = untracked
 [submodule "utils/haddock"]
 	path = utils/haddock
-	url = https://gitlab.haskell.org/ghc/haddock.git
+	url = https://gitlab.haskell.org/jaspervdj/haddock.git
 	ignore = untracked
-	branch = ghc-head
+	branch = da-master-8.8.1
 [submodule "nofib"]
 	path = nofib
 	url = https://gitlab.haskell.org/ghc/nofib.git


### PR DESCRIPTION
This repository is currently failing to build Haddock locally due to some changes we made regarding warnings:

```
utils/haddock/haddock-api/src/Haddock/Interface/Create.hs:299:3: error:
    • The constructor ‘DeprecatedTxt’ should have 3 arguments, but has been given 2
    • In the pattern: DeprecatedTxt _ msg
      In a case alternative:
          DeprecatedTxt _ msg
            -> format
            ...
```

[The fix is relatively easy](https://gitlab.haskell.org/jaspervdj/haddock/-/commit/7ba655e66614ca57c62d87f760cdf54806c08043), but this needs to be added to the Haddock git submodule, which complicates things.

We are not able to host a Haddock for on GitHub (without destroying the history), because the history contains some commits that GitHub considers invalid, e.g.:

```
commit 2b07607c4562034359f52b42055f8d2af4721ca4
Author:  <davve@dtek.chalmers.se>
Date:   Tue Apr 24 00:22:14 2007 +0000

    Use filepath package instead of FilePath
```

This is why I have (temporarily) created a fork on GitLab: https://gitlab.haskell.org/jaspervdj/haddock/-/tree/da-master-8.8.1