### PR TITLE
Remove AnyContractKey

### DIFF
--- a/DA/Internal/Desugar.hs
+++ b/DA/Internal/Desugar.hs
@@ -126,12 +126,6 @@ class HasFetchByKey t k | t -> k where
 class HasMaintainer t k | t -> k where
   _maintainer : proxy t -> k -> [Party]
 
-class HasToAnyContractKey t k | t -> k where
-  _toAnyContractKey : proxy t -> k -> Any
-
-class HasFromAnyContractKey t k | t -> k where
-  _fromAnyContractKey : proxy t -> Any -> Optional k
-
 class HasExerciseByKey t k c r | t -> k, t c -> r where
   _exerciseByKey : proxy t -> k -> c -> Update r
 

--- a/compiler/parser/RdrHsSyn.hs
+++ b/compiler/parser/RdrHsSyn.hs
@@ -3168,8 +3168,6 @@ mkKeyInstanceDecl templateName conName ValidTemplate{..}
        , mkInstance "HasFetchByKey" $ mkPrimMethod "fetchByKey" "UFetchByKey"
        , mkInstance "HasLookupByKey" $ mkPrimMethod "lookupByKey" "ULookupByKey"
        , mkInstance "HasQueryNByKey" $ mkPrimMethod "queryNByKey" "UQueryNByKey"
-       , mkInstance "HasToAnyContractKey" $ mkPrimMethod "_toAnyContractKey" "EToAnyContractKey"
-       , mkInstance "HasFromAnyContractKey" $ mkPrimMethod "_fromAnyContractKey" "EFromAnyContractKey"
        ]
   | otherwise = []
   where


### PR DESCRIPTION
Associated Daml PR: https://github.com/digital-asset/daml/pull/22802
Removes generated AnyContractKey instances, which have been replaced with daml-script specific coercion logic