### PR TITLE
make _lookupNByKey return an Optional

### DIFF
--- a/DA/Internal/Desugar.hs
+++ b/DA/Internal/Desugar.hs
@@ -119,7 +119,7 @@ class HasLookupByKey t k | t -> k where
 
 -- HasLookupNByKey = the NUCK lookup, briefly known as QueryNByKey
 class HasLookupNByKey t k | t -> k where
-  _lookupNByKey : Int -> k -> Update [(ContractId t, t)]
+  _lookupNByKey : Int -> k -> Update (Optional [(ContractId t, t)])
 
 class HasFetchByKey t k | t -> k where
   _fetchByKey : k -> Update (ContractId t, t)


### PR DESCRIPTION
In theory, damlc catches calls to lookupbykey with negative (yielding an error) or 0 (yielding the empty list []) n. That being said, to accomodate handwritten LF and to be a bit more precies, we wrap the lookupbykey in an optional, where None indicates failiure (such as a n < 1).

This PR implements the GHC side of this change

Daml companion PR: https://github.com/digital-asset/daml/pull/22894
Canton companion PR: https://github.com/DACH-NY/canton/pull/32018